### PR TITLE
✨ Feat :  상세페이지 상세이미지 img 배열 받아서 렌더링

### DIFF
--- a/src/components/units/Detail/client/DetailInfo/index.tsx
+++ b/src/components/units/Detail/client/DetailInfo/index.tsx
@@ -1,16 +1,19 @@
 'use client';
 
-import { IProductDetailType } from '../../types';
-import StoreInfo from '../StoreInfo';
-import BoardInfo from '../BoardInfo';
-import Button from '@/components/commons/button/client/Button';
-import ToastPop from '@/components/commons/ToastPop';
 import { MouseEvent, useState } from 'react';
-import { ChooseWishListModal } from '@/components/commons/card/ProductCard/client/ChooseWishListModal';
-import useToast from '@/commons/hooks/useToast';
+
 import Image from 'next/image';
+
+import useToast from '@/commons/hooks/useToast';
 import BtnOutlinedHeart from '@/components/commons/button/client/Btn_outlined_heart';
+import Button from '@/components/commons/button/client/Button';
+import { ChooseWishListModal } from '@/components/commons/card/ProductCard/client/ChooseWishListModal';
 import GrayDivider from '@/components/commons/divider/GrayDivider';
+import ToastPop from '@/components/commons/ToastPop';
+
+import { IProductDetailType } from '../../types';
+import BoardInfo from '../BoardInfo';
+import StoreInfo from '../StoreInfo';
 
 interface ProductInfoProps {
   data: IProductDetailType;
@@ -46,16 +49,23 @@ const ProductInfo = ({ data }: ProductInfoProps) => {
         <StoreInfo store={data.store} />
         <GrayDivider />
         <BoardInfo data={data} />
-        <div className="w-full">
-          <Image
-            src={'https://bbangree-oven.cdn.ntruss.com/1/1/1.jpg'}
-            alt="상세"
-            width={0}
-            height={0}
-            sizes="100vw"
-            className=" m-auto"
-            style={{ width: '100% ', padding: 0, margin: 0, marginBottom: '100px' }}
-          />
+        <div className="w-full p-0 ">
+          {data.board?.detail.map(item => (
+            <Image
+              key={item.imgIndex}
+              src={item.url}
+              alt="상세"
+              width={0}
+              height={0}
+              sizes="100vw"
+              className=" m-auto"
+              style={{
+                width: '100% ',
+                padding: 0,
+                margin: 0
+              }}
+            />
+          ))}
         </div>
       </div>
 

--- a/src/components/units/Detail/types/index.ts
+++ b/src/components/units/Detail/types/index.ts
@@ -33,7 +33,7 @@ export interface IProductDetailType {
     purchaseUrl: string;
     isWished: boolean;
     isBundled: boolean;
-    detail: string;
+    detail: [IDetailImageType];
     products: IProductType[];
   };
 }
@@ -41,4 +41,10 @@ export interface IProductDetailType {
 export interface IProductType {
   title: string;
   tags: string[];
+}
+
+export interface IDetailImageType {
+  id: number;
+  imgIndex: number;
+  url: string;
 }


### PR DESCRIPTION
## 이슈 번호

> close #177 

## 작업 내용 및 테스트 방법

> 
### DetailInfo.tsx 에서 data.board.detail 데이터로 상세페이지 이미지 렌더링
- 이를 위해 DetailType 수정을 하였고
- 아래와 같이 map으로 배열을 렌더링해주었습니다
```jsx
{data.board?.detail.map(item => (
            <Image
              key={item.imgIndex}
              src={item.url}
              alt="상세"
              width={0}
              height={0}
              sizes="100vw"
              className=" m-auto"
              style={{
                width: '100% ',
                padding: 0,
                margin: 0
              }}
            />
          ))}
```

## To reviewers
