### PR TITLE
✨ Feat : 전체페이지 상품 조회 요청 page -> cursorId로 수정

### DIFF
--- a/src/components/units/(main)/Products/api/getAllProducts.ts
+++ b/src/components/units/(main)/Products/api/getAllProducts.ts
@@ -5,14 +5,19 @@ import { transformFilterValueToQueryString } from '@/commons/utils/transformFilt
 
 interface GetAllProductsProps {
   query: IFilterType;
-  pageParam: number;
+  cursorId: number;
 }
 
 export const getAllProducts = async ({
   query,
-  pageParam
+  cursorId
 }: GetAllProductsProps): Promise<IAllProductsType> => {
-  const queryString = transformFilterValueToQueryString(query);
-  const data: IAllProductsType = await API.get(`/boards?${queryString}&page=${pageParam}`);
+  const firstPage = cursorId === -1;
+  const cursorIdQueryString = firstPage ? '' : `&cursorId=${cursorId}`;
+  const filterValueQueryString = transformFilterValueToQueryString(query);
+
+  const data: IAllProductsType = await API.get(
+    `/boards?${filterValueQueryString}${cursorIdQueryString}`
+  );
   return data;
 };

--- a/src/components/units/(main)/Products/hooks/useGetAllProductsQuery.ts
+++ b/src/components/units/(main)/Products/hooks/useGetAllProductsQuery.ts
@@ -5,11 +5,13 @@ import { getAllProducts } from '../api/getAllProducts';
 export const useGetAllProductsQuery = (query: IFilterType) => {
   const { data, ...rest } = useInfiniteQuery({
     queryKey: ['products', query],
-    queryFn: ({ pageParam }: { pageParam: number }) => getAllProducts({ query, pageParam }),
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, __, lastPageParam) => {
-      const nextPageParam = lastPage.last ? undefined : lastPageParam + 1;
-      return nextPageParam;
+    queryFn: ({ pageParam: cursorId }: { pageParam: number }) =>
+      getAllProducts({ query, cursorId }),
+    initialPageParam: -1,
+    getNextPageParam: lastPage => {
+      if (!lastPage.hasNext) return;
+      const nextCursorId = lastPage.content.at(-1)?.boardId;
+      return nextCursorId;
     },
     refetchOnMount: false,
     refetchOnReconnect: false,
@@ -18,7 +20,8 @@ export const useGetAllProductsQuery = (query: IFilterType) => {
   });
 
   const products = data?.pages.map(page => page.content).flat();
-  const itemCount = data?.pages[0]?.numberOfElements || 0;
+  const productCount = data?.pages[0]?.boardCnt || 0;
+  const storeCount = data?.pages[0]?.storeCnt || 0;
 
-  return { products, itemCount, ...rest };
+  return { products, productCount, storeCount, ...rest };
 };

--- a/src/components/units/(main)/Stores/hooks/useGetAllStoresQuery.ts
+++ b/src/components/units/(main)/Stores/hooks/useGetAllStoresQuery.ts
@@ -16,7 +16,6 @@ export const useGetAllStoresQuery = () => {
   });
 
   const stores = data?.pages.map(page => page.content).flat();
-  const itemCount = data?.pages[0]?.numberOfElements || 0;
 
-  return { stores, itemCount, ...rest };
+  return { stores, ...rest };
 };

--- a/src/components/units/(main)/client/ProductAndStoreTabWithCount/index.tsx
+++ b/src/components/units/(main)/client/ProductAndStoreTabWithCount/index.tsx
@@ -5,14 +5,11 @@ import { useRecoilValue } from 'recoil';
 import { filterValueState } from '@/domains/product/atoms';
 import { FILTER_FAMILY_ID } from '@/domains/product/constants/filterFamilyID';
 import { useGetAllProductsQuery } from '@/components/units/(main)/Products/hooks/useGetAllProductsQuery';
-import { useGetAllStoresQuery } from '@/components/units/(main)/Stores/hooks/useGetAllStoresQuery';
 import ProductAndStoreTab from '@/components/commons/tabs/ProductAndStoreTab';
 
 const ProductAndStoreTabWithCount = () => {
   const filterValue = useRecoilValue(filterValueState(FILTER_FAMILY_ID.main));
-
-  const { itemCount: productCount } = useGetAllProductsQuery(filterValue);
-  const { itemCount: storeCount } = useGetAllStoresQuery();
+  const { productCount, storeCount } = useGetAllProductsQuery(filterValue);
 
   return (
     <Suspense>

--- a/src/components/units/(main)/types/index.ts
+++ b/src/components/units/(main)/types/index.ts
@@ -3,29 +3,10 @@ import { IStoreType } from '@/commons/types/storeType';
 
 export interface IAllProductsType {
   content: IProductType[];
-  empty: boolean;
-  first: boolean;
-  last: boolean;
-  number: number;
-  numberOfElements: number;
-  pageable: {
-    offset: number;
-    pageNumber: number;
-    pageSize: number;
-    paged: boolean;
-    sort: {
-      empty: boolean;
-      sorted: boolean;
-      unsorted: boolean;
-    };
-    unpaged: boolean;
-  };
-  size: number;
-  sort: {
-    empty: boolean;
-    sorted: boolean;
-    unsorted: boolean;
-  };
+  requestCursor: number | null;
+  hasNext: boolean;
+  boardCnt: number;
+  storeCnt: number;
 }
 
 export interface IAllStoresType {


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

close #191 

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. 전체페이지에서 상품 조회 요청 시, `page`가 아닌 `cursorId`로 다음 페이지 요청

- 백엔드에서 상품 조회 로직을 '오프셋 기반'에서 '커서 기반'으로 개선함에 따라, 다음 페이지의 상품 조회 요청 시 `page`가 아닌 `cursorId`를 보내줘야 함
- 첫 페이지에 해당하는 상품 조회 요청 시에는 `cursorId`를 보내줄 필요가 없음
- 이슈) category를 cake 등으로 지정하고 요청 보낼 경우, 아이템이 10개가 아닌 3~4개씩 옴

### 2. 전체페이지 탭에 총 상품/스토어 개수를 표시함
![image](https://github.com/eco-dessert-platform/dessert-front/assets/98448226/fa7ed540-634d-471d-a640-90a6ae675cab)

- 첫 페이지에 해당하는 상품 조회 요청 시, 상품/스토어 총 아이템 개수를 제공 받음
- 이슈) **상품 전체 개수**가 아닌 **필터링된 상품의 총 개수**를 받아야 함

## To reviewers
상품 조회 api에 대한 response 데이터가 변경됨에 따라, 현재 로컬 뿐만 아니라 배포 사이트에서도 전체페이지로 들어가면 무한 요청이 발생하는 이슈가 나타납니다. 따라서, 오늘 가능하면 빨리 develop 브랜치를 배포 브랜치에 머지해야할 것 같습니다!
