### PR TITLE
🐛 Fix : 로그인 했을 때만 '최근 검색어 조회' api를 요청하도록 수정

### DIFF
--- a/src/domains/search/queries/useGetRecentSearchKeywordsQuery.ts
+++ b/src/domains/search/queries/useGetRecentSearchKeywordsQuery.ts
@@ -1,12 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+import { isLoggedinState } from '@/shared/atoms/login';
 import { SearchResultType } from '@/domains/search/types';
 import fetchExtend from '@/shared/utils/api';
 import QUERY_KEY from '@/shared/constants/queryKey';
 
 export const useGetRecentSearchKeywordsQuery = () => {
+  const isLoggedIn = useRecoilValue(isLoggedinState);
   const queryKey = [QUERY_KEY.search, QUERY_KEY.keyword];
 
   const queryFn = async () => {
+    if (!isLoggedIn) return [];
+
     const res = await fetchExtend.get('/search/recency');
     if (!res.ok) throw new Error('최근 검색어 조회 실패');
 


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

close #243 

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 로그인 했을 때만 '최근 검색어 조회' api를 요청하도록 수정했음

## To reviewers
