### PR TITLE
✨ Feat :  자동 로그인 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
         "optionalDependencies": false
       }
     ],
+    "@typescript-eslint/no-use-before-define": "off",
 
     // airbnb off (필요 없다고 생각하는 옵션 off)
     "import/prefer-default-export": "off",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-icons": "^5.0.1",
     "react-intersection-observer": "^9.8.1",
     "recoil": "^0.7.7",
+    "recoil-nexus": "^0.5.0",
     "swiper": "^11.0.5",
     "tailwind-merge": "^2.2.1",
     "tailwind-scrollbar-hide": "^1.1.7"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import ToastContainer from '@/global/ToastContainer';
 import Footer from '@/global/Footer';
 // import FlareLaneScript from '@/global/FlareLaneScript';
 // import RegisterServiceWorker from '@/global/RegisterServiceWorker';
+import SilentLogin from '@/global/SilentLogin';
 
 const pretendard = localFont({
   src: '../../public/assets/fonts/PretendardVariable.woff2'
@@ -28,6 +29,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => (
   <html lang="ko">
     <body className={pretendard.className}>
       <RootLayoutProvider>
+        <SilentLogin />
         <ModalContainer />
         <PopupContainer />
         <ToastContainer />

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -3,9 +3,10 @@ import UserInfoSection from '@/blocks/user/UserInfoSection';
 import MoreInfoSection from '@/blocks/user/MoreInfoSection';
 import { getCookie } from '@/shared/actions/cookie';
 import LoginSection from '@/blocks/user/LoginSection';
+import { TOKEN } from '@/shared/constants/token';
 
 const MyPage = async () => {
-  const accessToken = await getCookie('accessToken');
+  const accessToken = await getCookie(TOKEN.accessToken);
   const isLoggedIn = !!accessToken;
 
   return (

--- a/src/app/wish/layout.tsx
+++ b/src/app/wish/layout.tsx
@@ -1,5 +1,6 @@
 import { getCookie } from '@/shared/actions/cookie';
 import { ReactNode } from 'react';
+import { TOKEN } from '@/shared/constants/token';
 
 interface Props {
   children: ReactNode;
@@ -7,7 +8,7 @@ interface Props {
 }
 
 const Layout = async ({ children, login }: Props) => {
-  const accessToken = await getCookie('accessToken');
+  const accessToken = await getCookie(TOKEN.accessToken);
   const isLoggedIn = !!accessToken;
 
   return isLoggedIn ? children : login;

--- a/src/domains/search/queries/useDeleteRecentSearchKeywordMutation.tsx
+++ b/src/domains/search/queries/useDeleteRecentSearchKeywordMutation.tsx
@@ -31,8 +31,8 @@ export const useDeleteRecentSearchKeywordMutation = () => {
     return { previousKeywords };
   };
 
-  const onSuccess = () => {
-    queryClient.invalidateQueries({ queryKey });
+  const onSuccess = async () => {
+    await queryClient.invalidateQueries({ queryKey });
     openToast(<ToastPop>최근 검색어 삭제에 성공했어요</ToastPop>);
   };
 

--- a/src/domains/search/queries/useGetRecentSearchKeywordsQuery.ts
+++ b/src/domains/search/queries/useGetRecentSearchKeywordsQuery.ts
@@ -23,5 +23,10 @@ export const useGetRecentSearchKeywordsQuery = () => {
     errorMessage: '최근 검색어 조회에 실패했습니다'
   };
 
-  return useQuery({ queryKey, queryFn, meta });
+  return useQuery({
+    queryKey,
+    queryFn,
+    meta,
+    enabled: isLoggedIn
+  });
 };

--- a/src/domains/user/components/ProfileUpdateForm/MoreSection.tsx
+++ b/src/domains/user/components/ProfileUpdateForm/MoreSection.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useSetRecoilState } from 'recoil';
 import { twMerge } from 'tailwind-merge';
+import { TOKEN } from '@/shared/constants/token';
 
 interface Props {
   className?: string;
@@ -15,7 +16,7 @@ const MoreSection = ({ className }: Props) => {
   const setLogin = useSetRecoilState(isLoggedinState);
   const { push } = useRouter();
   const logout = async () => {
-    await Promise.all([deleteCookie('accessToken'), deleteCookie('refreshToken')]);
+    await Promise.all([deleteCookie(TOKEN.accessToken), deleteCookie(TOKEN.refreshToken)]);
     setLogin(false);
     push('/mypage');
   };

--- a/src/domains/user/queries/getAccessTokenFromRefreshToken.ts
+++ b/src/domains/user/queries/getAccessTokenFromRefreshToken.ts
@@ -1,0 +1,21 @@
+import fetchExtend from '@/shared/utils/api';
+import { AccessTokenType } from '@/domains/user/types/login';
+import { ResultResponse } from '@/shared/types/response';
+import { throwApiError } from '@/shared/utils/error';
+
+interface ResultType {
+  accessToken: AccessTokenType;
+}
+
+export const getAccessTokenFromRefreshToken = async (refreshToken: string) => {
+  const res = await fetchExtend.post('/token', {
+    body: JSON.stringify({ refreshToken })
+  });
+  const { result, success, code, message }: ResultResponse<ResultType> = await res.json();
+
+  if (!res.ok || !success) {
+    throwApiError({ code, message });
+  }
+
+  return result.accessToken;
+};

--- a/src/domains/user/queries/useLoginMutation.tsx
+++ b/src/domains/user/queries/useLoginMutation.tsx
@@ -9,18 +9,12 @@ import ToastPop from '@/shared/components/ToastPop';
 import { setCookie } from '@/shared/actions/cookie';
 import { ResultResponse } from '@/shared/types/response';
 import { throwApiError } from '@/shared/utils/error';
-import { expToDate, parseJwt } from '../utils/jwt';
+import { TOKEN } from '@/shared/constants/token';
+import { getExpFromToken, setTimerForAccessTokenExp } from '../utils/jwt';
 
 interface LoginResponse {
   accessToken: string;
   refreshToken: string;
-}
-
-interface ParsedJWT {
-  exp: number;
-  iat: number;
-  id: number;
-  iss: number;
 }
 
 const useLoginMutation = () => {
@@ -38,26 +32,24 @@ const useLoginMutation = () => {
   };
 
   const onSuccess = async ({ accessToken, refreshToken }: LoginResponse) => {
-    const { exp: accessTokenExp }: ParsedJWT = parseJwt(accessToken);
-    const { exp: refreshTokenExp }: ParsedJWT = parseJwt(refreshToken);
-
-    const accessTokenExpireDate = expToDate(accessTokenExp);
-    const refreshTokenExpireDate = expToDate(refreshTokenExp);
+    const accessTokenExp = getExpFromToken(accessToken);
+    const refreshTokenExp = getExpFromToken(refreshToken);
 
     await Promise.all([
       setCookie({
-        name: 'accessToken',
+        name: TOKEN.accessToken,
         value: accessToken,
-        expires: accessTokenExpireDate
+        expires: accessTokenExp
       }),
       setCookie({
-        name: 'refreshToken',
+        name: TOKEN.refreshToken,
         value: refreshToken,
-        expires: refreshTokenExpireDate
+        expires: refreshTokenExp
       })
     ]);
     openToast(<ToastPop>로그인 되었어요.</ToastPop>);
 
+    setTimerForAccessTokenExp();
     setLogin(true);
     replace(PATH.home);
   };

--- a/src/domains/user/types/login.ts
+++ b/src/domains/user/types/login.ts
@@ -1,13 +1,23 @@
+export type AccessTokenType = string;
+export type RefreshTokenType = string;
+
 export interface LoginResponse {
-  accessToken: string;
-  refreshToken: string;
+  accessToken: AccessTokenType;
+  refreshToken: RefreshTokenType;
 }
 
 export interface KakaoAuthResponse {
-  access_token: string;
+  access_token: AccessTokenType;
   token_type: string;
-  refresh_token: string;
+  refresh_token: RefreshTokenType;
   expires_in: number;
   scope: string;
   refresh_token_expires_in: number;
+}
+
+export interface ParsedJWT {
+  exp: number;
+  iat: number;
+  id: number;
+  iss: number;
 }

--- a/src/domains/user/utils/jwt.ts
+++ b/src/domains/user/utils/jwt.ts
@@ -1,12 +1,59 @@
-export function parseJwt(token: string) {
+import { getCookie, setCookie, deleteCookie } from '@/shared/actions/cookie';
+import { TOKEN, MAX_AGE } from '@/shared/constants/token';
+import { ParsedJWT } from '@/domains/user/types/login';
+import { getAccessTokenFromRefreshToken } from '@/domains/user/queries/getAccessTokenFromRefreshToken';
+import { isLoggedinState } from '@/shared/atoms/login';
+import { setRecoil } from 'recoil-nexus';
+import { getErrorMessage } from '@/shared/utils/error';
+
+export const parseJwt = (token: string) => {
   const payloadBase64 = token.split('.')[1];
   const decodedPayload = window.atob(payloadBase64);
-  const decoded = JSON.parse(decodedPayload);
+  const decoded: ParsedJWT = JSON.parse(decodedPayload);
 
   return decoded;
-}
+};
 
-export function expToDate(exp: number) {
+export const expToDate = (exp: number) => {
   const expireDate = new Date(exp * 1000);
   return expireDate;
-}
+};
+
+export const getExpFromToken = (token: string) => {
+  const { exp: accessTokenExpInSec } = parseJwt(token);
+  return accessTokenExpInSec * 1000; // 단위: ms
+};
+
+export const setTimerForAccessTokenExp = () => {
+  const fiveMinute = 5 * 60 * 1000;
+  const delay = MAX_AGE.accessToken * 1000 - fiveMinute; // 단위: ms
+
+  return setTimeout(silentLogin, delay);
+};
+
+export const silentLogin = async () => {
+  try {
+    // refresh token을 보내 새 access token 받기
+    const res = await getCookie(TOKEN.refreshToken);
+    if (!res) return;
+
+    const refreshToken = res.value;
+    const accessToken = await getAccessTokenFromRefreshToken(refreshToken);
+
+    // 쿠키에 새 access token 저장
+    await setCookie({
+      name: TOKEN.accessToken,
+      value: accessToken,
+      expires: getExpFromToken(accessToken)
+    });
+
+    // isLoggedInState atom 설정
+    setRecoil(isLoggedinState, true);
+
+    // access token 타이머 설정
+    setTimerForAccessTokenExp();
+  } catch (error) {
+    deleteCookie(TOKEN.accessToken);
+    console.error('[자동 로그인 실패]: ', getErrorMessage(error));
+  }
+};

--- a/src/global/RootLayoutProvider.tsx
+++ b/src/global/RootLayoutProvider.tsx
@@ -4,9 +4,11 @@ import { ReactNode } from 'react';
 import { RecoilRoot } from 'recoil';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import CustomQueryClientProvider from '@/global/CustomQueryClientProvider';
+import RecoilNexus from 'recoil-nexus';
 
 const RootLayoutProvider = ({ children }: { children: ReactNode }) => (
   <RecoilRoot>
+    <RecoilNexus />
     <CustomQueryClientProvider>
       {children}
       <ReactQueryDevtools initialIsOpen={false} />

--- a/src/global/SilentLogin.tsx
+++ b/src/global/SilentLogin.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+import { silentLogin } from '@/domains/user/utils/jwt';
+
+const SilentLogin = () => {
+  useEffect(() => {
+    silentLogin();
+  }, []);
+
+  return null;
+};
+
+export default SilentLogin;

--- a/src/shared/actions/cookie.ts
+++ b/src/shared/actions/cookie.ts
@@ -14,7 +14,7 @@ export const setCookie = async ({
 }: {
   name: string;
   value: string;
-  expires?: Date;
+  expires?: number; // 단위: ms
 }) => {
   cookies().set({
     name,

--- a/src/shared/constants/token.ts
+++ b/src/shared/constants/token.ts
@@ -1,0 +1,9 @@
+export const TOKEN = {
+  accessToken: 'accessToken',
+  refreshToken: 'refreshToken'
+};
+
+export const MAX_AGE = {
+  accessToken: 3 * 60 * 60, // 3시간 (단위: s)
+  refreshToken: 2 * 7 * 24 * 60 * 60 // 2주 (단위: s)
+};

--- a/src/shared/utils/api.ts
+++ b/src/shared/utils/api.ts
@@ -1,10 +1,11 @@
+import { TOKEN } from '@/shared/constants/token';
 import { getCookie } from '../actions/cookie';
 import { API_URL } from '../constants/api';
 
 const API_V1_URL = `${API_URL}/api/v1`;
 
 const getAccessToken = async () => {
-  const accessToken = await getCookie('accessToken');
+  const accessToken = await getCookie(TOKEN.accessToken);
   return accessToken?.value;
 };
 

--- a/src/shared/utils/error.ts
+++ b/src/shared/utils/error.ts
@@ -6,3 +6,8 @@ interface Props {
 export function throwApiError({ code, message }: Props) {
   throw new Error(`[ERROR ${code}] ${message}`);
 }
+
+export function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6593,6 +6593,7 @@ __metadata:
     react-icons: "npm:^5.0.1"
     react-intersection-observer: "npm:^9.8.1"
     recoil: "npm:^0.7.7"
+    recoil-nexus: "npm:^0.5.0"
     storybook: "npm:^8.0.8"
     swiper: "npm:^11.0.5"
     tailwind-merge: "npm:^2.2.1"
@@ -12101,6 +12102,19 @@ __metadata:
     tiny-invariant: "npm:^1.3.3"
     tslib: "npm:^2.0.1"
   checksum: 10c0/589c1a96aea7656a844f56278ffe99e3360717991955e9409221f2c1582a922f8179c803c8d35ca61743facfa0ad895acfe73dcc76076e0717db04c508166d44
+  languageName: node
+  linkType: hard
+
+"recoil-nexus@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "recoil-nexus@npm:0.5.0"
+  peerDependencies:
+    "@types/react": ">=16.8.0"
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+    recoil: ">=0.2.0"
+    typescript: ">=4.1.0"
+  checksum: 10c0/5534d9b5daa7f7b2c340161bdc9b91f7ea1edb2932b181dbcbe21c2d15c8d83c7f9a7c2a8b4a6f3462bcd60987092e55da659aff22f32b07379580e7eb281287
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

close #200 

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. `recoil-nexus` 패키지 설치

- 기능: component나 hook 이외의 일반 함수에서도 recoil state를 가져오거나 수정 가능하게 함

```js
// 사용 예
import { loadingState } from "../atoms/loadingState";
import { getRecoil, setRecoil } from "recoil-nexus";

export default function toggleLoading() {
  const loading = getRecoil(loadingState);
  setRecoil(loadingState, !loading);
}
```

- 설치 이유: `silentLogin`라는 일반 함수에서 `isLoggedInState` 값을 수정하기 위해 설치했음

```js

export const silentLogin = async () => {
  try {
    ...
    // isLoggedInState atom 설정
    setRecoil(isLoggedinState, true);
    ...
  }
  ...
};
```

### 2. 자동 로그인 구현

```
accessToken 유효기한(max-age): 3시간
refreshToken 유효기한(max-age): 2주
```

1. 로그인 직후, 타이머를 설정해 3시간(accessToken 유효기한)이 지나기 5분 전에 accessToken을 갱신해 로그인을 연장함
2. 새로고침 시(또는 refreshToken이 유효한 기간 내 재방문 시), accessToken을 갱신해 자동 로그인 되도록 함

### 3. 토큰 변수화

```js
export const TOKEN = {
  accessToken: 'accessToken',
  refreshToken: 'refreshToken'
};
```

```js
// 사용 예
const MyPage = async () => {
  const accessToken = await getCookie(TOKEN.accessToken);
  ...
};
```

### 4. `.eslintrc.json` 수정  

- 수정 사항: `"@typescript-eslint/no-use-before-define": "off"`로 수정
- 수정 이유: 'domains/user/utils/jwt.ts'에서 `setTimerForAccessTokenExp` 함수와 `slientLogin` 함수 내부에서 각각 서로를 호출하고 있어서, eslint 위 옵션에 의해 `setTimerForAccessTokenExp` 함수에서 `slientLogin` 함수를 정의하기 전 호출했다는 에러가 떠서 off로 변경해주었음 (다른 방법이 있다면 피드백 주시면 감사하겠습니다🙏)

### 5. '최근 검색어 조회' useQuey 수정

- 로그인 상태일 때, '최근 검색어 조회' 요청을 보내도록 useQuery에 `enabled` 옵션 추가

## To reviewers

다들 pull 받으시고 `yarn install` 해주세요~