### PR TITLE
💄 Design: 마이페이지 typo 수정

### DIFF
--- a/src/app/mypage/(policy)/notifications/[id]/page.tsx
+++ b/src/app/mypage/(policy)/notifications/[id]/page.tsx
@@ -14,7 +14,7 @@ const NotificationDetail = async ({ params: { id } }: NotificationDetailProps) =
   return (
     <>
       <NotificationTitle title={notification.title} date={notification.createdAt} isBigTitle />
-      <PaddingWrapper className="leading-150 text-14 text-gray-900 tracking-tight-2">
+      <PaddingWrapper className="text-gray-900 typo-title-14-regular">
         {notification.content}
       </PaddingWrapper>
     </>

--- a/src/app/mypage/(policy)/privacy-policy/page.tsx
+++ b/src/app/mypage/(policy)/privacy-policy/page.tsx
@@ -1,7 +1,7 @@
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
 
 const PrivacyPolicy = () => (
-  <PaddingWrapper className="leading-150 text-14 text-gray-900 tracking-tight-2">
+  <PaddingWrapper className="text-gray-900 typo-title-14-regular">
     개인정보 처리방침 및 수집이용 동의 관련 내용입니다.
   </PaddingWrapper>
 );

--- a/src/app/mypage/(policy)/service-terms/page.tsx
+++ b/src/app/mypage/(policy)/service-terms/page.tsx
@@ -1,7 +1,7 @@
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
 
 const ServiceTerms = () => (
-  <PaddingWrapper className="leading-150 text-14 text-gray-900 tracking-tight-2">
+  <PaddingWrapper className="text-gray-900 typo-title-14-regular">
     서비스 이용 약관관련 내용입니다.
   </PaddingWrapper>
 );

--- a/src/app/mypage/update/layout.tsx
+++ b/src/app/mypage/update/layout.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 const Layout = ({ children }: Props) => (
   <>
-    <Header title="회원 수정" back />
+    <Header title="프로필 수정" back />
     {children}
   </>
 );

--- a/src/blocks/user/LoginSection.tsx
+++ b/src/blocks/user/LoginSection.tsx
@@ -10,7 +10,7 @@ const LoginSection = () => (
     <Link href={PATH.login} className="w-full">
       <Button variants="primary-orange">로그인/회원가입</Button>
     </Link>
-    <p className="text-14 tracking-tight-2 leading-150 text-gray-800">
+    <p className="text-gray-800 typo-title-14-regular">
       회원가입 및 로그인을 하고 더 많은 정보들을 받아보세요! 🎉
     </p>
   </PaddingWrapper>

--- a/src/blocks/user/MoreInfoSection.tsx
+++ b/src/blocks/user/MoreInfoSection.tsx
@@ -43,7 +43,7 @@ const LOGGEDIN_INFOS = [
 const MoreInfoItem = ({ icon, content }: MoreInfoItemProps) => (
   <PaddingWrapper className="flex items-center gap-[8px] border-solid border-b-[1px] border-gray-100">
     {icon}
-    <p className="text-[14px] font-medium">{content}</p>
+    <p className="typo-title-14-medium">{content}</p>
   </PaddingWrapper>
 );
 

--- a/src/blocks/user/UserInfoSection.tsx
+++ b/src/blocks/user/UserInfoSection.tsx
@@ -25,13 +25,13 @@ const UserInfoSection = async () => {
               <BbangleIcon shape="smile" className="w-[30px] h-[30px]" />
             )}
           </div>
-          <p className="text-18 text-gray-900 font-bold tracking-tight">{nickname}</p>
+          <p className="text-gray-900 typo-title-16-semibold">{nickname}</p>
         </div>
         <Link href={PATH.profileUpdate}>
-          <p className="text-11 text-gray-500 tracking-tight-2 leading-150">프로필 수정</p>
+          <p className="text-gray-500 typo-body-11-regular">프로필 수정</p>
         </Link>
       </div>
-      <p className="text-14 text-gray-800 tracking-tight-2">반가워요 :) 무엇을 도와드릴까요?</p>
+      <p className="text-gray-800 typo-title-14-regular">반가워요 :) 무엇을 도와드릴까요?</p>
     </PaddingWrapper>
   );
 };

--- a/src/blocks/user/login/LoginLogoSection.tsx
+++ b/src/blocks/user/login/LoginLogoSection.tsx
@@ -11,7 +11,7 @@ const LoginLogoSection = ({ title, subTitle }: Props) => (
   <div className="flex flex-col items-center justify-center gap-[20px]">
     <BbangleIcon shape="vertical-name" />
     <div>
-      <div className="typo-title-16-semibold text-center text-gray-900 ">{title}</div>
+      <div className="typo-title-16-semibold text-center text-gray-900">{title}</div>
       <div className="typo-title-14-regular text-center text-gray-800">{subTitle}</div>
     </div>
   </div>

--- a/src/blocks/user/withdraw/WithdrawLogoSection.tsx
+++ b/src/blocks/user/withdraw/WithdrawLogoSection.tsx
@@ -5,11 +5,9 @@ const WithdrawLogoSection = () => (
     <div className="flex justify-center items-center w-[80px] h-[80px]">
       <BbangleIcon shape="cry" />
     </div>
-    <div className="leading-normal tracking-tight text-center">
-      <p className="text-[16px] font-semibold">빵그리의 오븐과 이별인가요?</p>
-      <p className="text-[14px] font-normal">
-        계정을 삭제하면 내가 찜한 모든 상품들이 사라지게 돼요
-      </p>
+    <div className="text-center">
+      <p className="typo-title-16-semibold">빵그리의 오븐과 이별인가요?</p>
+      <p className="typo-title-14-medium">계정을 삭제하면 내가 찜한 모든 상품들이 사라지게 돼요</p>
     </div>
   </div>
 );

--- a/src/domains/user/components/NotificationTitle.tsx
+++ b/src/domains/user/components/NotificationTitle.tsx
@@ -8,9 +8,13 @@ interface NotificationTitleProps {
 }
 
 const NotificationTitle = ({ title, date, isBigTitle = false }: NotificationTitleProps) => (
-  <PaddingWrapper className="flex flex-col gap-[2px] border-solid border-b border-gray-100 leading-150 tracking-tight-2">
-    <p className={`${isBigTitle ? 'text-16' : 'text-[14px]'} text-gray-900 font-medium`}>{title}</p>
-    <p className="text-12 text-gray-500 tracking-2 leading-150">{date}</p>
+  <PaddingWrapper className="flex flex-col gap-[2px] border-solid border-b border-gray-100">
+    <p
+      className={`${isBigTitle ? 'typo-title-16-semibold' : 'typo-title-14-semibold'} text-gray-900`}
+    >
+      {title}
+    </p>
+    <p className="text-gray-500 typo-body-12-regular">{date}</p>
   </PaddingWrapper>
 );
 

--- a/src/domains/user/components/ProfileUpdateForm/ButtonSection.tsx
+++ b/src/domains/user/components/ProfileUpdateForm/ButtonSection.tsx
@@ -3,7 +3,7 @@ import Button from '@/shared/components/Button';
 const ButtonSection = () => (
   <div className="fixed z-[5000] left-1/2 -translate-x-1/2 bottom-0 w-full max-w-[600px] p-[16px] bg-white">
     <Button type="submit" variants="primary-black">
-      완료
+      수정하기
     </Button>
   </div>
 );

--- a/src/domains/user/components/ProfileUpdateForm/MoreSection.tsx
+++ b/src/domains/user/components/ProfileUpdateForm/MoreSection.tsx
@@ -22,11 +22,13 @@ const MoreSection = ({ className }: Props) => {
   };
 
   return (
-    <div className={twMerge('flex justify-between text-gray-600 typo-body-12-regular', className)}>
+    <div className={twMerge('flex justify-between typo-body-12-regular', className)}>
       <Link href="/mypage/withdraw">
-        <button type="button">회원탈퇴</button>
+        <button type="button" className="text-gray-600">
+          회원탈퇴
+        </button>
       </Link>
-      <button type="button" onClick={logout}>
+      <button type="button" className="text-gray-900" onClick={logout}>
         로그아웃
       </button>
     </div>

--- a/src/domains/user/components/ProfileUpdateForm/MoreSection.tsx
+++ b/src/domains/user/components/ProfileUpdateForm/MoreSection.tsx
@@ -22,7 +22,7 @@ const MoreSection = ({ className }: Props) => {
   };
 
   return (
-    <div className={twMerge('flex justify-between text-gray-600 text-sm', className)}>
+    <div className={twMerge('flex justify-between text-gray-600 typo-body-12-regular', className)}>
       <Link href="/mypage/withdraw">
         <button type="button">회원탈퇴</button>
       </Link>

--- a/src/domains/user/components/ProfileUpdateForm/index.tsx
+++ b/src/domains/user/components/ProfileUpdateForm/index.tsx
@@ -2,7 +2,6 @@
 
 import { FormEventHandler } from 'react';
 import { useRecoilValue } from 'recoil';
-import Button from '@/shared/components/Button';
 import BirthdayInput from '@/domains/user/components/common/BirthdateInput';
 import MoreSection from '@/domains/user/components/ProfileUpdateForm/MoreSection';
 import NicknameInput from '@/domains/user/components/common/NickNameInput';
@@ -11,6 +10,7 @@ import ProfileImageInput from '@/domains/user/components/common/ProfileImageInpu
 import { UserProfileType } from '@/domains/user/types/profile';
 import useProfileUpdateMutation from '@/domains/user/queries/useProfileUpdateMutation';
 import { updateFormState } from '@/domains/user/atoms/profile';
+import ButtonSection from '@/domains/user/components/ProfileUpdateForm/ButtonSection';
 
 interface ProfileUpdateFormProps {
   defaultValues: UserProfileType;
@@ -29,7 +29,7 @@ const ProfileUpdateForm = ({
 
   return (
     <form className="px-[16px]" onSubmit={onSubmit}>
-      <div className="my-[16px] flex flex-col w-full justify-center items-center">
+      <div className="my-[16px] flex justify-center items-center">
         <ProfileImageInput defaultValue={profileImg ?? undefined} />
       </div>
       <div className="flex flex-col gap-[20px] mb-[36px]">
@@ -37,10 +37,8 @@ const ProfileUpdateForm = ({
         <PhoneNumberInput defaultValue={phoneNumber ?? undefined} />
         <BirthdayInput defaultValue={birthDate ?? undefined} />
       </div>
-      <div>
-        <MoreSection className="mb-[16px]" />
-        <Button type="submit">수정하기</Button>
-      </div>
+      <MoreSection className="mb-[16px]" />
+      <ButtonSection />
     </form>
   );
 };

--- a/src/domains/user/components/RecommendForm/CheckSection/RecommendItem.tsx
+++ b/src/domains/user/components/RecommendForm/CheckSection/RecommendItem.tsx
@@ -19,11 +19,13 @@ const RecommendItem = ({ name, title, description, isChecked, onChange }: Props)
   >
     <div className="flex flex-col">
       <p
-        className={`${isChecked ? 'text-primaryOrangeRed' : 'text-gray-900'} text-[14px] font-medium`}
+        className={`${isChecked ? 'text-primaryOrangeRed typo-title-14-semibold' : 'text-gray-900 typo-title-14-medium'}`}
       >
         {title}
       </p>
-      <p className={`${isChecked ? 'text-primaryOrangeRed' : 'text-gray-700'} text-[14px]`}>
+      <p
+        className={`${isChecked ? 'text-primaryOrangeRed typo-title-14-semibold' : 'text-gray-700 typo-title-14-regular'}`}
+      >
         {description}
       </p>
     </div>

--- a/src/domains/user/components/RecommendForm/DescriptionSection.tsx
+++ b/src/domains/user/components/RecommendForm/DescriptionSection.tsx
@@ -1,5 +1,5 @@
 const DescriptionSection = () => (
-  <div className="flex items-center justify-center gap-2 text-[16px] font-semibold text-gray-900 mb-[16px]">
+  <div className="flex items-center justify-center gap-2 typo-title-16-semibold text-gray-900 mb-[16px]">
     <p>
       빵그리의 오븐을 찾은 이유를 <span className="text-primaryOrangeRed">최대 2가지 </span>
       선택해주세요

--- a/src/domains/user/components/RegistrationForm/CheckSection.tsx
+++ b/src/domains/user/components/RegistrationForm/CheckSection.tsx
@@ -3,9 +3,15 @@
 import { ChangeEvent } from 'react';
 import CheckBox from '@/shared/components/Checkbox';
 import { useRecoilState } from 'recoil';
+import { twMerge } from 'tailwind-merge';
+import GrayDivider from '@/shared/components/GrayDivider';
 import { agreeState } from '../../atoms/profile';
 
-const CheckSection = () => {
+interface Props {
+  className?: string;
+}
+
+const CheckSection = ({ className }: Props) => {
   const [agree, setAgree] = useRecoilState(agreeState);
 
   const checkAll = (e: ChangeEvent<HTMLInputElement>) => {
@@ -45,11 +51,12 @@ const CheckSection = () => {
     agree.isAllowingMarketing && agree.isPersonalInfoConsented && agree.isTermsOfServiceAccepted;
 
   return (
-    <div className="flex flex-col gap-[16px] w-full">
+    <div className={twMerge('flex flex-col gap-[16px] w-full', className)}>
       <CheckBox name="" isChecked={allChecked} onChange={checkAll}>
-        <span className="text-base text-gray-900">모두 동의합니다.</span>
+        <span className="typo-title-16-medium text-gray-900">모두 동의합니다.</span>
       </CheckBox>
-      <hr />
+      <GrayDivider color="gray100" />
+      <p className="typo-body-12-regular text-primaryOrangeRed">유효성체크문구영역</p>
       <CheckBox
         name="isTermsOfServiceAccepted"
         required

--- a/src/domains/user/components/RegistrationForm/index.tsx
+++ b/src/domains/user/components/RegistrationForm/index.tsx
@@ -5,11 +5,11 @@ import { useRecoilValue } from 'recoil';
 import BirthdayInput from '@/domains/user/components/common/BirthdateInput';
 import NicknameInput from '@/domains/user/components/common/NickNameInput';
 import PhoneNumberInput from '@/domains/user/components/common/PhoneNumberInput';
+import ButtonSection from '@/domains/user/components/RegistrationForm/ButtonSection';
 import { registrationFormState } from '../../atoms/profile';
 import useRegistrationMutation from '../../queries/useRegistrationMutation';
 import ProfileImageInput from '../common/ProfileImageInput';
 import CheckSection from './CheckSection';
-import ButtonSection from './ButtonSection';
 
 const RegistrationForm = () => {
   const registrationForm = useRecoilValue(registrationFormState);
@@ -22,19 +22,16 @@ const RegistrationForm = () => {
   };
 
   return (
-    <form
-      ref={formRef}
-      className="px-[16px] flex flex-col items-center gap-[36px]"
-      onSubmit={onSubmit}
-    >
-      <div className="w-full flex flex-col gap-[20px] items-center">
+    <form ref={formRef} className="px-[16px]" onSubmit={onSubmit}>
+      <div className="my-[16px] flex justify-center items-center">
         <ProfileImageInput />
+      </div>
+      <div className="flex flex-col gap-[20px] mb-[56px]">
         <NicknameInput />
         <PhoneNumberInput />
         <BirthdayInput />
-        <CheckSection />
       </div>
-
+      <CheckSection className="mb-[32px]" />
       <ButtonSection />
     </form>
   );

--- a/src/domains/user/components/WithdrawForm/Agree.tsx
+++ b/src/domains/user/components/WithdrawForm/Agree.tsx
@@ -9,11 +9,7 @@ interface AgreeProps {
 
 const Agree = ({ isChecked, onChange }: AgreeProps) => (
   <CheckBox isChecked={isChecked} onChange={onChange}>
-    <div
-      className={`underline underline-offset-2 text-[12px] font-medium ${
-        isChecked ? 'text-primaryOrangeRed' : 'text-gray-900'
-      }`}
-    >
+    <div className={`typo-body-12-medium ${isChecked ? 'text-primaryOrangeRed' : 'text-gray-900'}`}>
       회원탈퇴 유의사항을 확인했으며 이에 동의합니다.
     </div>
   </CheckBox>

--- a/src/domains/user/components/WithdrawForm/WithdrawButton.tsx
+++ b/src/domains/user/components/WithdrawForm/WithdrawButton.tsx
@@ -17,9 +17,11 @@ const WithdrawButton = ({ disabled = true }: WithdrawButtonProps) => {
   };
 
   return (
-    <Button onClick={handleClickButton} disabled={disabled}>
-      탈퇴하기
-    </Button>
+    <div className="fixed z-[5000] left-1/2 -translate-x-1/2 bottom-0 w-full max-w-[600px] p-[16px] bg-white">
+      <Button onClick={handleClickButton} disabled={disabled}>
+        탈퇴하기
+      </Button>
+    </div>
   );
 };
 

--- a/src/domains/user/components/WithdrawForm/index.tsx
+++ b/src/domains/user/components/WithdrawForm/index.tsx
@@ -24,12 +24,12 @@ const WithdrawForm = () => {
   return (
     <form id="withdraw-form" onSubmit={handleFormSubmit}>
       <div>
-        <p className="mb-4 text-[14px] font-semibold tracking-tight">
+        <p className="mb-[8px] typo-title-14-semibold">
           계정을 삭제하는 이유를 알려주세요😢
-          <span className="text-[12px] text-gray-400">(중복선택가능)</span>
+          <span className="typo-body-12-semibold text-gray-400">(중복선택가능)</span>
         </p>
         <DeleteReasonList />
-        <div className="flex justify-center mt-[20px] mb-[32px] ">
+        <div className="flex justify-center mt-[20px] mb-[32px]">
           <Agree isChecked={isAgreeChecked} onChange={handleAgreeChange} />
         </div>
       </div>

--- a/src/domains/user/components/alert-box/WithdrawPopup.tsx
+++ b/src/domains/user/components/alert-box/WithdrawPopup.tsx
@@ -2,6 +2,7 @@
 
 import Popup from '@/shared/components/Popup';
 import usePopup from '@/shared/hooks/usePopup';
+import PaddingWrapper from '@/shared/components/PaddingWrapper';
 
 const WithdrawPopup = () => {
   const { closePopup } = usePopup();
@@ -12,24 +13,30 @@ const WithdrawPopup = () => {
 
   return (
     <Popup>
-      <div className="leading-normal tracking-tight">
-        <p className="p-4 text-center font-medium">정말로 탈퇴 하시겠어요?</p>
-        <p className="p-4 text-center text-[14px]">
+      <div>
+        <PaddingWrapper className="text-center typo-title-16-medium">
+          정말로 탈퇴 하시겠어요?
+        </PaddingWrapper>
+        <PaddingWrapper className="text-center typo-title-14-regular">
           탈퇴 버튼 선택시,
           <br />
           계정은 삭제되며 복구되지 않습니다.
-        </p>
-        <div className="flex justify-around p-4">
+        </PaddingWrapper>
+        <PaddingWrapper className="flex justify-around">
+          <button
+            type="button"
+            className="typo-title-14-medium cursor-pointer"
+            onClick={handleClickCancel}
+          >
+            취소
+          </button>
           <input
             type="submit"
             form="withdraw-form"
             value="탈퇴하기"
-            className="text-primaryOrangeRed text-[14px] underline underline-offset-2 cursor-pointer"
+            className="text-primaryOrangeRed typo-title-14-medium cursor-pointer"
           />
-          <button type="button" className="text-[14px] cursor-pointer" onClick={handleClickCancel}>
-            취소
-          </button>
-        </div>
+        </PaddingWrapper>
       </div>
     </Popup>
   );

--- a/src/domains/user/components/common/NickNameInput.tsx
+++ b/src/domains/user/components/common/NickNameInput.tsx
@@ -36,8 +36,14 @@ const NicknameInput = ({ defaultValue }: NicknameInputProps) => {
         required
         maxLength={20}
         defaultValue={defaultValue}
+        className="typo-title-14-medium"
         button={
-          <Button type="button" variants="input" onClick={checkDouble}>
+          <Button
+            type="button"
+            variants="input"
+            className="typo-body-12-medium"
+            onClick={checkDouble}
+          >
             중복확인
           </Button>
         }

--- a/src/domains/user/components/common/NickNameInput.tsx
+++ b/src/domains/user/components/common/NickNameInput.tsx
@@ -42,7 +42,9 @@ const NicknameInput = ({ defaultValue }: NicknameInputProps) => {
           </Button>
         }
       />
-      {data?.message && <div className="h-4 text-xs mt-[4px] text-gray-600">{data.message}</div>}
+      {data?.message && (
+        <div className="mt-[4px] text-gray-600 typo-body-12-medium">{data.message}</div>
+      )}
     </div>
   );
 };

--- a/src/domains/user/components/common/PhoneNumberInput.tsx
+++ b/src/domains/user/components/common/PhoneNumberInput.tsx
@@ -34,10 +34,16 @@ const PhoneNumberInput = ({ defaultValue }: PhoneNumberInputProps) => {
     <div className="w-full">
       <Input
         type="tel"
-        label="휴대폰 번호"
+        label="휴대폰번호"
         placeholder="010-1234-5678"
         button={
-          <Button disabled type="button" variants="input" onClick={() => {}}>
+          <Button
+            disabled
+            type="button"
+            variants="input"
+            className="typo-body-12-medium"
+            onClick={() => {}}
+          >
             인증하기
           </Button>
         }

--- a/src/domains/user/components/common/ProfileImageInput.tsx
+++ b/src/domains/user/components/common/ProfileImageInput.tsx
@@ -41,9 +41,12 @@ const ProfileImageInput = ({ defaultValue }: ProfileImageInputProps) => {
       {imgSrc ? (
         <Image src={imgSrc} alt="profile preview" width={100} height={100} />
       ) : (
-        <BbangleIcon shape="smile" className="w-[80px] h-[80px] fill-gray-300" />
+        <BbangleIcon
+          shape="smile"
+          className="w-[80px] h-[80px] fill-gray-300 translate-y-[-10px]"
+        />
       )}
-      <div className="absolute h-[26px] bottom-0 w-full text-center text-white bg-gray-800/50 typo-title-14-medium">
+      <div className="absolute bottom-0 flex justify-center items-center h-[26px] w-full text-white bg-gray-800/50 typo-title-14-semibold">
         편집
       </div>
     </label>

--- a/src/domains/user/components/common/ProfileImageInput.tsx
+++ b/src/domains/user/components/common/ProfileImageInput.tsx
@@ -43,7 +43,7 @@ const ProfileImageInput = ({ defaultValue }: ProfileImageInputProps) => {
       ) : (
         <BbangleIcon shape="smile" className="w-[80px] h-[80px] fill-gray-300" />
       )}
-      <div className="absolute h-[26px] leading-[26px] bottom-0 w-full text-center text-white bg-gray-800/50">
+      <div className="absolute h-[26px] bottom-0 w-full text-center text-white bg-gray-800/50 typo-title-14-medium">
         편집
       </div>
     </label>

--- a/src/shared/components/Checkbox.tsx
+++ b/src/shared/components/Checkbox.tsx
@@ -29,7 +29,7 @@ const CheckBox = ({
     <label
       htmlFor={id}
       className={twMerge(
-        'flex items-center gap-[6px] text-gray-900 text-14 font-normal leading-150 tracking-tight-2 cursor-pointer',
+        'flex items-center gap-[6px] text-gray-900 typo-title-14-regular cursor-pointer',
         className
       )}
     >

--- a/src/shared/components/GrayDivider.tsx
+++ b/src/shared/components/GrayDivider.tsx
@@ -1,3 +1,24 @@
-const GrayDivider = () => <div className="border-b border-gray-50 border-solid" />;
+import { GrayColorType } from '@/shared/types/color';
+
+interface GrayDividerProps {
+  color?: GrayColorType;
+}
+
+const bgColor = {
+  gray50: 'bg-gray-50',
+  gray100: 'bg-gray-100',
+  gray200: 'bg-gray-200',
+  gray300: 'bg-gray-300',
+  gray400: 'bg-gray-400',
+  gray500: 'bg-gray-500',
+  gray600: 'bg-gray-600',
+  gray700: 'bg-gray-700',
+  gray800: 'bg-gray-800',
+  gray900: 'bg-gray-900'
+};
+
+const GrayDivider = ({ color = 'gray50' }: GrayDividerProps) => (
+  <hr className={`h-[1px] border-0 ${bgColor[color]}`} />
+);
 
 export default GrayDivider;

--- a/src/shared/components/Input.tsx
+++ b/src/shared/components/Input.tsx
@@ -13,7 +13,7 @@ const Input = ({ id, label, button, required, className, ...props }: Props) => {
   return (
     <div id={id} className="w-full">
       {label && (
-        <label className="inline-block mb-[6px]" htmlFor={inputId}>
+        <label className="inline-block mb-[6px] typo-title-14-semibold" htmlFor={inputId}>
           {label} {required && <span className="text-primaryOrangeRed">*</span>}
         </label>
       )}

--- a/src/shared/types/color.ts
+++ b/src/shared/types/color.ts
@@ -1,0 +1,11 @@
+export type GrayColorType =
+  | 'gray50'
+  | 'gray100'
+  | 'gray200'
+  | 'gray300'
+  | 'gray400'
+  | 'gray500'
+  | 'gray600'
+  | 'gray700'
+  | 'gray800'
+  | 'gray900';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -37,10 +37,7 @@ module.exports = {
         primaryOrangeRed: '#F04C28',
         subColorPink: '#FEEDEA',
         secondaryPink: '#FDF1EE',
-        secondaryOrangeRed: '#ED5F5F',
-        redGray: {
-          30: '#F8F8F8'
-        }
+        secondaryOrangeRed: '#ED5F5F'
       },
 
       // fontSize, lineHeight,letterSpacing 삭제 예정


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

close #346 

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. 마이페이지 typo 수정

### 2. 프로필 등록/수정/삭제 페이지 스타일 수정

- '유효성체크문구영역' 텍스트 추가
- Footer 위로 버튼 올림
- 프로필 등록 페이지에서 '건너뛰기' 버튼 삭제  

### 3. `GrayDivider` 컴포넌트에 color prop 추가

- gray-50부터 gray-900까지 색상 변경 가능

```js
import { GrayColorType } from '@/shared/types/color';

interface GrayDividerProps {
  color?: GrayColorType;
}

const bgColor = {
  gray50: 'bg-gray-50',
  gray100: 'bg-gray-100',
  gray200: 'bg-gray-200',
  gray300: 'bg-gray-300',
  gray400: 'bg-gray-400',
  gray500: 'bg-gray-500',
  gray600: 'bg-gray-600',
  gray700: 'bg-gray-700',
  gray800: 'bg-gray-800',
  gray900: 'bg-gray-900'
};

const GrayDivider = ({ color = 'gray50' }: GrayDividerProps) => (
  <hr className={`h-[1px] border-0 ${bgColor[color]}`} />
);

export default GrayDivider;
```

## To reviewers

프로필 등록 페이지에서 하단 약관 '보기' 관련한 부분은 현재 기획팀에 질문을 드린 상태라 나중에 답변 받게 되면 수정해서 다시 pr 올리겠습니다!