### PR TITLE
✨ Feat : 프로필 등록 페이지 '보기' 링크 추가

### DIFF
--- a/src/app/mypage/(policy)/marketing/layout.tsx
+++ b/src/app/mypage/(policy)/marketing/layout.tsx
@@ -1,0 +1,15 @@
+import Header from '@/shared/components/Header';
+import { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+const Layout = ({ children }: Props) => (
+  <>
+    <Header title="마케팅 수신 정보 이용 동의" back />
+    {children}
+  </>
+);
+
+export default Layout;

--- a/src/app/mypage/(policy)/marketing/page.tsx
+++ b/src/app/mypage/(policy)/marketing/page.tsx
@@ -1,0 +1,9 @@
+import PaddingWrapper from '@/shared/components/PaddingWrapper';
+
+const PrivacyPolicy = () => (
+  <PaddingWrapper className="text-gray-900 typo-title-14-regular">
+    마케팅 수신 정보 이용 동의 관련 내용입니다.
+  </PaddingWrapper>
+);
+
+export default PrivacyPolicy;

--- a/src/blocks/home/HomeLogoSection.tsx
+++ b/src/blocks/home/HomeLogoSection.tsx
@@ -5,7 +5,7 @@ import PaddingWrapper from '@/shared/components/PaddingWrapper';
 import { BbangleIcon } from '@/shared/components/icons';
 
 const HomeLogoSection = () => (
-  <PaddingWrapper className="bg-white">
+  <PaddingWrapper className="pb-0 bg-white">
     <h1>
       <Link href="/">
         <BbangleIcon shape="horizontal-name" />

--- a/src/blocks/home/SearchSection.tsx
+++ b/src/blocks/home/SearchSection.tsx
@@ -3,7 +3,7 @@ import SearchInput from '@/domains/search/components/SearchInput';
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
 
 const SearchSection = () => (
-  <PaddingWrapper className="py-0 bg-white sticky top-0 z-[4999]">
+  <PaddingWrapper className="bg-white sticky top-0 z-[4999]">
     <Link href="/search">
       <SearchInput readOnly placeholder="궁금한 상품을 찾아보세요!" />
     </Link>

--- a/src/domains/user/components/RegistrationForm/CheckSection/ViewLinkWrapper.tsx
+++ b/src/domains/user/components/RegistrationForm/CheckSection/ViewLinkWrapper.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+interface ViewLinkWrapperProps {
+  href: string;
+  children: string;
+}
+
+const ViewLinkWrapper = ({ href, children }: ViewLinkWrapperProps) => (
+  <div className="flex justify-between items-center w-full">
+    <p>{children}</p>
+    <Link href={href} className="typo-body-12-regular-underline text-gray-500">
+      보기
+    </Link>
+  </div>
+);
+
+export default ViewLinkWrapper;

--- a/src/domains/user/components/RegistrationForm/CheckSection/index.tsx
+++ b/src/domains/user/components/RegistrationForm/CheckSection/index.tsx
@@ -5,7 +5,9 @@ import CheckBox from '@/shared/components/Checkbox';
 import { useRecoilState } from 'recoil';
 import { twMerge } from 'tailwind-merge';
 import GrayDivider from '@/shared/components/GrayDivider';
-import { agreeState } from '../../atoms/profile';
+import ViewLinkWrapper from '@/domains/user/components/RegistrationForm/CheckSection/ViewLinkWrapper';
+import PATH from '@/shared/constants/path';
+import { agreeState } from '../../../atoms/profile';
 
 interface Props {
   className?: string;
@@ -63,7 +65,7 @@ const CheckSection = ({ className }: Props) => {
         isChecked={agree.isTermsOfServiceAccepted}
         onChange={onChangeService}
       >
-        [필수] 서비스 이용약관
+        <ViewLinkWrapper href={PATH.serviceTerm}>[필수] 서비스 이용약관</ViewLinkWrapper>
       </CheckBox>
       <CheckBox
         name="isPersonalInfoConsented"
@@ -71,14 +73,18 @@ const CheckSection = ({ className }: Props) => {
         isChecked={agree.isPersonalInfoConsented}
         onChange={onChangePersonalInfo}
       >
-        [필수] 개인 정보 처리방침 및 수집이용 동의
+        <ViewLinkWrapper href={PATH.privacyPolicy}>
+          [필수] 개인 정보 처리방침 및 수집이용 동의
+        </ViewLinkWrapper>
       </CheckBox>
       <CheckBox
         name="isAllowingMarketing"
         isChecked={agree.isAllowingMarketing}
         onChange={onChangeMarketing}
       >
-        [선택] 마케팅 수신 정보 및 이용 동의
+        <ViewLinkWrapper href={PATH.marketing}>
+          [선택] 마케팅 수신 정보 및 이용 동의
+        </ViewLinkWrapper>
       </CheckBox>
     </div>
   );

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -1,17 +1,16 @@
 'use client';
 
 import React from 'react';
-
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
-
 import ArrowIcons from './icons/ArrowIcons';
 
 interface HeaderProps {
   title?: String;
+  content?: React.ReactNode;
   back?: boolean;
 }
 
-const Header = ({ title, back = false }: HeaderProps) => {
+const Header = ({ title, content, back = false }: HeaderProps) => {
   const goBackHandler = () => {
     window.history.back();
   };
@@ -28,7 +27,10 @@ const Header = ({ title, back = false }: HeaderProps) => {
           <ArrowIcons shape="back" />
         </button>
       )}
-      <h2 className="typo-title-16-medium">{title}</h2>
+      <div className="flex justify-between items-center w-full">
+        <h2 className="typo-title-16-medium">{title}</h2>
+        {content}
+      </div>
     </PaddingWrapper>
   );
 };

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -15,6 +15,7 @@ const PATH = {
   notification: '/mypage/notifications',
   serviceTerm: '/mypage/service-terms',
   privacyPolicy: '/mypage/privacy-policy',
+  marketing: '/mypage/marketing',
   login: '/mypage/login',
   mypage: '/mypage'
 };

--- a/src/stories/Header.stories.tsx
+++ b/src/stories/Header.stories.tsx
@@ -26,3 +26,9 @@ export const WithBackButton: Story = {
     back: true
   }
 };
+
+export const WithContent: Story = {
+  args: {
+    content: <p className="typo-title-16-medium text-gray-500">1/2</p>
+  }
+};


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

close #366 

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1. 프로필 등록 페이지 '보기' 링크 추가

- '보기' 링크 추가

<img src='https://github.com/eco-dessert-platform/dessert-front/assets/98448226/66c6f21a-8329-41c1-b4b2-cdc4bdf6854f' width='500'/>

- '마케팅 정보 수신 및 이용 동의' 페이지 생성

<img src='https://github.com/eco-dessert-platform/dessert-front/assets/98448226/de2b944b-98ed-4f12-bebb-f85a951c39cb' width='500'/>

### 2. 홈페이지 검색창 스타일 수정

- `SearchSection` py-0 -> py-[16px]로 수정하는 대신, `LogoSection` pb-[16px] -> pb-0으로 변경

### 3. `Header` 컴포넌트에 content prop 추가

- 헤더 우측 부분에 ReactNode 추가 가능

```js
interface HeaderProps {
  ...
  content?: React.ReactNode;
}

const Header = ({ title, content, back = false }: HeaderProps) => {
  return (
    <PaddingWrapper className="flex items-center h-[60px] py-[10px]">
      ...
      <div className="flex justify-between items-center w-full">
        <h2 className="typo-title-16-medium">{title}</h2>
        {content}
      </div>
    </PaddingWrapper>
  );
};

```

#### 상세페이지

![image](https://github.com/eco-dessert-platform/dessert-front/assets/98448226/6e8a3e72-7909-4650-aae1-e3bac47a7f9f)

#### 리뷰 작성 페이지

![image](https://github.com/eco-dessert-platform/dessert-front/assets/98448226/97956d4c-12a7-4c34-b816-eaddbdd728e9)


## To reviewers
