### PR TITLE
✨ Feat : 상품 찜 폴더 변경하기 기능 

### DIFF
--- a/src/blocks/home/BestProductsSection/ProductsList.tsx
+++ b/src/blocks/home/BestProductsSection/ProductsList.tsx
@@ -1,14 +1,14 @@
 import { ResultResponse } from '@/shared/types/response';
 import { IProductListType, IProductType } from '@/domains/product/types/productType';
 import ProductCard from '@/domains/product/components/ProductCard';
-import { REAVALIDATE_TAG } from '@/shared/constants/revalidateTags';
 import fetchExtend from '@/shared/utils/api';
 import { throwApiError } from '@/shared/utils/error';
+import { productQueryKey } from '@/shared/queries/queryKey';
 
 const getBestProducts = async () => {
   const res = await fetchExtend.get('/boards', {
     next: {
-      tags: [REAVALIDATE_TAG.product]
+      tags: productQueryKey.list('home')
     }
   });
   const { result, success, message, code }: ResultResponse<IProductListType> = await res.json();

--- a/src/domains/product/components/ProductCard/ProductImage/index.tsx
+++ b/src/domains/product/components/ProductCard/ProductImage/index.tsx
@@ -10,6 +10,8 @@ import { RankingBadge } from '@/domains/product/components/ProductCard/ProductIm
 import useAddWishProductMutation from '@/domains/wish/queries/useAddWishProductMutation';
 import useDeleteWishProductMutation from '@/domains/wish/queries/useDeleteWishProductMutation';
 import HeartButton from '@/shared/components/HeartButton';
+import { selectedWishFolderState } from '@/domains/wish/atoms/wishFolder';
+import { useRecoilValue } from 'recoil';
 
 interface ProductImageProps {
   product: IProductType;
@@ -17,15 +19,15 @@ interface ProductImageProps {
   ranking?: number;
 }
 const ProductImage = ({ product, popular, ranking }: ProductImageProps) => {
-  const DEFAULT_FOLDER_ID = '0';
   const BLUR_DATA_URL =
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg==';
+  const selectedWishFolder = useRecoilValue(selectedWishFolderState);
 
   const { mutate: addMutate } = useAddWishProductMutation();
   const { mutate: deleteMutate } = useDeleteWishProductMutation();
 
   const like: MouseEventHandler<HTMLButtonElement> = (e) => {
-    addMutate({ productId: String(product.boardId), folderId: DEFAULT_FOLDER_ID });
+    addMutate({ productId: String(product.boardId), folderId: selectedWishFolder });
     e.preventDefault();
   };
 

--- a/src/domains/product/queries/useGetAllProductsQuery.ts
+++ b/src/domains/product/queries/useGetAllProductsQuery.ts
@@ -1,14 +1,14 @@
 import { IAllProductsType } from '@/domains/product/types/allProductsType';
 import { IFilterType } from '@/domains/product/types/filterType';
 import { transformFilterValueToQueryString } from '@/domains/product/utils/transformFilterValueToQueryString';
-import QUERY_KEY from '@/shared/constants/queryKey';
+import { productQueryKey } from '@/shared/queries/queryKey';
 import { ResultResponse } from '@/shared/types/response';
 import fetchExtend from '@/shared/utils/api';
 import { throwApiError } from '@/shared/utils/error';
 import { GetNextPageParamFunction, useInfiniteQuery } from '@tanstack/react-query';
 
 export const useGetAllProductsQuery = (query: IFilterType) => {
-  const queryKey = [QUERY_KEY.product, QUERY_KEY.main, { query }];
+  const queryKey = productQueryKey.list('home');
 
   const queryFn = async ({
     pageParam

--- a/src/domains/wish/atoms/wishFolder.ts
+++ b/src/domains/wish/atoms/wishFolder.ts
@@ -1,6 +1,12 @@
 import { atom } from 'recoil';
+import { DEFAULT_FOLDER_ID } from '../constants';
 
 export const isWishFolderEditingState = atom({
   key: 'wishFolder',
   default: false
+});
+
+export const selectedWishFolderState = atom({
+  key: 'selectedWishFolder',
+  default: DEFAULT_FOLDER_ID
 });

--- a/src/domains/wish/components/WishFolder/index.test.tsx
+++ b/src/domains/wish/components/WishFolder/index.test.tsx
@@ -8,7 +8,7 @@ describe('<WishFolder/> 테스트', () => {
   test('폴더 명과 찜 개수가 노출된다.', () => {
     render(
       <RootLayoutProvider>
-        <WishFolder id={0} name="폴더" count={10} />
+        <WishFolder id="0" name="폴더" count={10} />
       </RootLayoutProvider>
     );
 
@@ -22,7 +22,7 @@ describe('<WishFolder/> 테스트', () => {
   test('폴더 상세 페이지로 이동하는 href 속성을 가진다.', () => {
     render(
       <RootLayoutProvider>
-        <WishFolder id={0} name="폴더" count={10} />
+        <WishFolder id="0" name="폴더" count={10} />
       </RootLayoutProvider>
     );
 

--- a/src/domains/wish/components/WishFolder/index.tsx
+++ b/src/domains/wish/components/WishFolder/index.tsx
@@ -13,7 +13,7 @@ import UpdateWishFolderModal from '../alert-box/UpdateWishFolderModal';
 import FolderThumbnail from '../common/FolderThumbnail';
 
 interface WishFolderProps {
-  id: number;
+  id: string;
   thumbnailList?: string[];
   name: string;
   count: number;

--- a/src/domains/wish/components/alert-box/DeleteWishFolderPopup.tsx
+++ b/src/domains/wish/components/alert-box/DeleteWishFolderPopup.tsx
@@ -7,7 +7,7 @@ import usePopup from '@/shared/hooks/usePopup';
 import useDeleteWishFolderMutation from '../../queries/useDeleteWishFolderMutation';
 
 interface DeleteWishFolderPopupProps {
-  folderId: number;
+  folderId: string;
   folderName: string;
 }
 

--- a/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
+++ b/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
@@ -9,7 +9,7 @@ import useInput from '@/shared/hooks/useInput';
 import useUpdateWishFolderMutation from '../../queries/useUpdateWishFolderMutation';
 
 interface UpdateWishFolderModalProps {
-  folderId: number;
+  folderId: string;
 }
 
 const UpdateWishFolderModal = ({ folderId }: UpdateWishFolderModalProps) => {

--- a/src/domains/wish/components/alert-box/WishFolderSelectModal.tsx
+++ b/src/domains/wish/components/alert-box/WishFolderSelectModal.tsx
@@ -1,15 +1,29 @@
 'use client';
 
+import { useSetRecoilState } from 'recoil';
 import Modal from '@/shared/components/Modal';
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
 import { PlusIcon } from '@/shared/components/icons';
 import FolderThumbnail from '../common/FolderThumbnail';
 import useWishFolderListQuery from '../../queries/useWishFolderListQuery';
+import { selectedWishFolderState } from '../../atoms/wishFolder';
+/** 기획상 순환이 발생 */
+// eslint-disable-next-line import/no-cycle
+import useMoveWishProduct from '../../queries/useMoveWishProduct';
 
-const WishFolderSelectModal = () => {
+interface Props {
+  productId: string;
+}
+
+const WishFolderSelectModal = ({ productId }: Props) => {
   const { data } = useWishFolderListQuery();
+  const setSelectedWishFolder = useSetRecoilState(selectedWishFolderState);
+  const { mutate } = useMoveWishProduct();
 
-  if (!data || data.length === 0) return <>임시</>;
+  const moveTo = async ({ folderId, folderName }: { folderId: string; folderName: string }) => {
+    setSelectedWishFolder(folderId);
+    mutate({ productId, folderId, folderName });
+  };
 
   return (
     <Modal title="찜 폴더" className="font-semibold text-[14px] text-gray-800">
@@ -23,8 +37,13 @@ const WishFolderSelectModal = () => {
           </PaddingWrapper>
         </button>
 
-        {data.map(({ count, folderId, title, productImages }) => (
-          <button type="button" key={folderId} className="border-t border-gray-100">
+        {data?.map(({ count, folderId, title, productImages }) => (
+          <button
+            type="button"
+            key={folderId}
+            className="border-t border-gray-100"
+            onClick={() => moveTo({ folderId, folderName: title })}
+          >
             <PaddingWrapper className="flex items-center gap-[10px]">
               <FolderThumbnail size="sm" thumbnailList={productImages} />
               <div className="flex items-center">

--- a/src/domains/wish/constants/index.ts
+++ b/src/domains/wish/constants/index.ts
@@ -1,3 +1,5 @@
 import { SortOption } from '../atoms/wishProducts';
 
 export const SORT_OPTIONS: SortOption[] = ['담은순', '인기순', '저가순'];
+
+export const DEFAULT_FOLDER_ID = '0';

--- a/src/domains/wish/queries/service.ts
+++ b/src/domains/wish/queries/service.ts
@@ -1,5 +1,5 @@
 import Service from '@/shared/queries/service';
-import { Cursor, ResultResponse } from '@/shared/types/response';
+import { Cursor, DefaultResponse, ResultResponse } from '@/shared/types/response';
 import { throwApiError } from '@/shared/utils/error';
 import { IStoreType } from '@/domains/store/types/store';
 
@@ -11,6 +11,21 @@ class WishService extends Service {
     const { result, success, code, message }: ResultResponse<Cursor<IStoreType>> = await res.json();
     if (!res.ok || !success) throwApiError({ code, message });
     return result;
+  }
+
+  async addWishProduct({ folderId, productId }: { folderId: string; productId: string }) {
+    const res = await this.fetchExtend.post(`/boards/${productId}/wish`, {
+      body: JSON.stringify({ folderId })
+    });
+    const { success, code, message }: DefaultResponse = await res.json();
+    if (!res.ok || !success) throwApiError({ code, message });
+    return { productId, folderId };
+  }
+
+  async deleteWishProduct({ productId }: { productId: string }) {
+    const res = await this.fetchExtend.put(`/boards/${productId}/cancel`);
+    const { success, code, message }: DefaultResponse = await res.json();
+    if (!res.ok || !success) throwApiError({ code, message });
   }
 }
 

--- a/src/domains/wish/queries/service.ts
+++ b/src/domains/wish/queries/service.ts
@@ -1,7 +1,7 @@
 import Service from '@/shared/queries/service';
 import { Cursor, DefaultResponse, ResultResponse } from '@/shared/types/response';
-import { throwApiError } from '@/shared/utils/error';
 import { IStoreType } from '@/domains/store/types/store';
+import { ERROR_MESSAGE } from '@/shared/constants/error';
 
 class WishService extends Service {
   async getWishStoreList(cursorId: number) {
@@ -9,7 +9,7 @@ class WishService extends Service {
     const params = isFirstPage ? '' : `cursorId=${cursorId}`;
     const res = await this.fetchExtend.get(`/likes/stores?${params}`);
     const { result, success, code, message }: ResultResponse<Cursor<IStoreType>> = await res.json();
-    if (!res.ok || !success) throwApiError({ code, message });
+    if (!res.ok || !success) throw new Error(ERROR_MESSAGE.api({ code, message }));
     return result;
   }
 
@@ -17,15 +17,17 @@ class WishService extends Service {
     const res = await this.fetchExtend.post(`/boards/${productId}/wish`, {
       body: JSON.stringify({ folderId })
     });
+    if (res.status === 401) {
+      throw Error(ERROR_MESSAGE.requiredLogin);
+    }
     const { success, code, message }: DefaultResponse = await res.json();
-    if (!res.ok || !success) throwApiError({ code, message });
-    return { productId, folderId };
+    if (!res.ok || !success) throw new Error(ERROR_MESSAGE.api({ code, message }));
   }
 
   async deleteWishProduct({ productId }: { productId: string }) {
     const res = await this.fetchExtend.put(`/boards/${productId}/cancel`);
     const { success, code, message }: DefaultResponse = await res.json();
-    if (!res.ok || !success) throwApiError({ code, message });
+    if (!res.ok || !success) throw new Error(ERROR_MESSAGE.api({ code, message }));
   }
 }
 

--- a/src/domains/wish/queries/useAddWishProductMutation.tsx
+++ b/src/domains/wish/queries/useAddWishProductMutation.tsx
@@ -1,3 +1,4 @@
+import { useRecoilValue } from 'recoil';
 import { useMutation } from '@tanstack/react-query';
 import useModal from '@/shared/hooks/useModal';
 import useToast from '@/shared/hooks/useToast';
@@ -6,14 +7,17 @@ import { revalidateTag } from '@/shared/actions/revalidate';
 import { REAVALIDATE_TAG } from '@/shared/constants/revalidateTags';
 import { ERROR_MESSAGE } from '@/shared/constants/error';
 import RequiredLoginToast from '@/shared/components/RequiredLoginToast';
+import { isLoggedinState } from '@/shared/atoms/login';
 import wishService from './service';
 import WishFolderSelectModal from '../components/alert-box/WishFolderSelectModal';
 
 const useAddWishProductMutation = () => {
   const { openToast } = useToast();
   const { openModal } = useModal();
+  const isLoggedIn = useRecoilValue(isLoggedinState);
 
   const mutationFn = async ({ productId, folderId }: { productId: string; folderId: string }) => {
+    if (!isLoggedIn) throw new Error(ERROR_MESSAGE.requiredLogin);
     await wishService.addWishProduct({ productId, folderId });
     return { productId };
   };

--- a/src/domains/wish/queries/useAddWishProductMutation.tsx
+++ b/src/domains/wish/queries/useAddWishProductMutation.tsx
@@ -1,29 +1,23 @@
 import { useMutation } from '@tanstack/react-query';
 import useModal from '@/shared/hooks/useModal';
 import useToast from '@/shared/hooks/useToast';
-import fetchExtend from '@/shared/utils/api';
 import ToastPop from '@/shared/components/ToastPop';
 import { revalidateTag } from '@/shared/actions/revalidate';
 import { REAVALIDATE_TAG } from '@/shared/constants/revalidateTags';
-import { DefaultResponse } from '@/shared/types/response';
-import { throwApiError } from '@/shared/utils/error';
 import WishFolderSelectModal from '../components/alert-box/WishFolderSelectModal';
+import wishService from './service';
 
 const useAddWishProductMutation = () => {
   const { openToast } = useToast();
   const { openModal } = useModal();
 
-  const mutationFn = async ({ productId, folderId }: { productId: string; folderId: string }) => {
-    const res = await fetchExtend.post(`/boards/${productId}/wish`, {
-      body: JSON.stringify({ folderId })
-    });
-    const { success, code, message }: DefaultResponse = await res.json();
-    if (!res.ok || !success) throwApiError({ code, message });
-  };
+  const mutationFn = ({ productId, folderId }: { productId: string; folderId: string }) =>
+    wishService.addWishProduct({ productId, folderId });
 
-  const onSuccess = async () => {
-    const openFolderSelectModal = () => openModal(<WishFolderSelectModal />);
+  const onSuccess = async ({ productId }: { productId: string; folderId: string }) => {
     await revalidateTag(REAVALIDATE_TAG.product);
+    const openFolderSelectModal = () => openModal(<WishFolderSelectModal productId={productId} />);
+
     openToast(
       <ToastPop>
         <div>💖 찜한 상품에 추가했어요</div>

--- a/src/domains/wish/queries/useDeleteWishFolderMutation.tsx
+++ b/src/domains/wish/queries/useDeleteWishFolderMutation.tsx
@@ -10,7 +10,7 @@ import { throwApiError } from '@/shared/utils/error';
 const useDeleteWishFolderMutation = () => {
   const { openToast } = useToast();
 
-  const mutationFn = async (folderId: number) => {
+  const mutationFn = async (folderId: string) => {
     const res = await fetchExtend.delete(`/wishLists/${folderId}`, {
       method: 'DELETE'
     });

--- a/src/domains/wish/queries/useDeleteWishProductMutation.tsx
+++ b/src/domains/wish/queries/useDeleteWishProductMutation.tsx
@@ -1,20 +1,25 @@
 import useToast from '@/shared/hooks/useToast';
 import fetchExtend from '@/shared/utils/api';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import ToastPop from '@/shared/components/ToastPop';
 import { DefaultResponse } from '@/shared/types/response';
 import { throwApiError } from '@/shared/utils/error';
+import { productQueryKey } from '@/shared/queries/queryKey';
+import { revalidateTag } from '@/shared/actions/revalidate';
 
 const useDeleteWishProductMutation = () => {
   const { openToast } = useToast();
+  const queryClient = useQueryClient();
 
   const mutationFn = async ({ productId }: { productId: string }) => {
-    const res = await fetchExtend.patch(`/boards/${productId}/wish`);
+    const res = await fetchExtend.put(`/boards/${productId}/cancel`);
     const { success, code, message }: DefaultResponse = await res.json();
     if (!res.ok || !success) throwApiError({ code, message });
   };
 
   const onSuccess = () => {
+    revalidateTag(productQueryKey.all[0]);
+    queryClient.invalidateQueries({ queryKey: productQueryKey.all });
     openToast(
       <ToastPop>
         <div>💖 찜 해제 되었어요</div>

--- a/src/domains/wish/queries/useMoveWishProduct.tsx
+++ b/src/domains/wish/queries/useMoveWishProduct.tsx
@@ -1,0 +1,60 @@
+import { useMutation } from '@tanstack/react-query';
+import useToast from '@/shared/hooks/useToast';
+import ToastPop from '@/shared/components/ToastPop';
+import useModal from '@/shared/hooks/useModal';
+import { revalidatePath } from '@/shared/actions/revalidate';
+import PATH from '@/shared/constants/path';
+import wishService from './service';
+/** 기획상 순환이 발생 */
+// eslint-disable-next-line import/no-cycle
+import WishFolderSelectModal from '../components/alert-box/WishFolderSelectModal';
+
+const useMoveWishProduct = () => {
+  const { openToast } = useToast();
+  const { openModal, closeModal } = useModal();
+
+  const mutationFn = async ({
+    productId,
+    folderId,
+    folderName
+  }: {
+    productId: string;
+    folderId: string;
+    folderName: string;
+  }) => {
+    await wishService.deleteWishProduct({ productId });
+    await wishService.addWishProduct({ productId, folderId });
+    return { productId, folderName };
+  };
+
+  const onSuccess = ({ productId, folderName }: { productId: string; folderName: string }) => {
+    revalidatePath(PATH.wishProductList);
+    const openFolderSelectModal = () => openModal(<WishFolderSelectModal productId={productId} />);
+    closeModal();
+    openToast(
+      <ToastPop>
+        <div>{folderName}에 추가했어요</div>
+        <button type="button" className="hover:underline" onClick={openFolderSelectModal}>
+          편집
+        </button>
+      </ToastPop>
+    );
+  };
+
+  const onError = (error: Error) => {
+    closeModal();
+    openToast(
+      <ToastPop>
+        <div>{error.message}</div>
+      </ToastPop>
+    );
+  };
+
+  return useMutation({
+    mutationFn,
+    onSuccess,
+    onError
+  });
+};
+
+export default useMoveWishProduct;

--- a/src/domains/wish/queries/useUpdateWishFolderMutation.tsx
+++ b/src/domains/wish/queries/useUpdateWishFolderMutation.tsx
@@ -10,7 +10,7 @@ import { throwApiError } from '@/shared/utils/error';
 const useUpdateWishFolderMutation = () => {
   const { openToast } = useToast();
 
-  const mutationFn = async ({ folderId, title }: { folderId: number; title: string }) => {
+  const mutationFn = async ({ folderId, title }: { folderId: string; title: string }) => {
     const res = await fetchExtend.patch(`/wishLists/${folderId}`, {
       body: JSON.stringify({ title })
     });

--- a/src/domains/wish/types/wishFolder.ts
+++ b/src/domains/wish/types/wishFolder.ts
@@ -1,7 +1,7 @@
 import { IProductType } from '@/domains/product/types/productType';
 
 export interface WishFolderType {
-  folderId: number;
+  folderId: string;
   title: string;
   count: number;
   productImages: string[];

--- a/src/shared/components/RequiredLoginToast.tsx
+++ b/src/shared/components/RequiredLoginToast.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { ERROR_MESSAGE } from '../constants/error';
+import PATH from '../constants/path';
+import ToastPop from './ToastPop';
+
+const RequiredLoginToast = () => (
+  <ToastPop>
+    <span>{ERROR_MESSAGE.requiredLogin}</span>
+    <Link className="hover:underline" href={PATH.login}>
+      로그인
+    </Link>
+  </ToastPop>
+);
+
+export default RequiredLoginToast;

--- a/src/shared/constants/error.ts
+++ b/src/shared/constants/error.ts
@@ -1,0 +1,4 @@
+export const ERROR_MESSAGE = {
+  requiredLogin: '로그인이 필요합니다.',
+  api: ({ code, message }: { code: number; message: string }) => `[${code}] ${message}`
+};

--- a/src/shared/queries/queryKey.ts
+++ b/src/shared/queries/queryKey.ts
@@ -1,0 +1,5 @@
+export const productQueryKey = {
+  all: ['product'],
+  lists: () => [...productQueryKey.all, 'list'],
+  list: (filter: string) => [...productQueryKey.lists(), filter]
+};

--- a/src/shared/utils/error.ts
+++ b/src/shared/utils/error.ts
@@ -3,10 +3,9 @@ interface Props {
   message: string;
 }
 
+/**
+ * @deprecated @/shared/constants/error.ts 의 ERROR_MESSAGE를 사용해주세요.
+ * */
 export function throwApiError({ code, message }: Props) {
   throw new Error(`[ERROR ${code}] ${message}`);
-}
-
-export function getApiErrorMessage({ code, message }: Props) {
-  return Error(`[ERROR ${code}] ${message}`);
 }

--- a/src/shared/utils/error.ts
+++ b/src/shared/utils/error.ts
@@ -6,3 +6,7 @@ interface Props {
 export function throwApiError({ code, message }: Props) {
   throw new Error(`[ERROR ${code}] ${message}`);
 }
+
+export function getApiErrorMessage({ code, message }: Props) {
+  return Error(`[ERROR ${code}] ${message}`);
+}


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

close #367

## 작업 내용 및 테스트 방법

### 1. 찜 삭제 기능

백엔드 API 변경된거 반영했습니다. 

### 2. 찜 모달


찜 모달 기능에서 dependency cycle이 생기는데, 해결을 못했습니다.
어제 부터 계속 고민 해봤는데 어거지로 해결할 수는 있지만,
오히려 코드가 더 더러워지는것 같아서 lint 옵션 끄는걸로 처리해뒀어요.
좋은 방법 있다면 알려주세요 ㅠㅠ

![image](https://github.com/eco-dessert-platform/dessert-front/assets/77661228/0a48e35a-9037-45d1-94ba-92cb1a68bee0)



### 3. 비로그인 처리


axios가 아니라 fetch를 쓰는 입장에서 이거보다 좋은 방법이 안떠올라서
message기반으로 처리했습니다.


```ts
// 상수
export const ERROR_MESSAGE = {
  requiredLogin: '로그인이 필요합니다.',
  api: ({ code, message }: { code: number; message: string }) => `[${code}] ${message}`
};


// Service
class WishService extends Service {
  // ...
  async addWishProduct({ folderId, productId }: { folderId: string; productId: string }) {
    const res = await this.fetchExtend.post(`/boards/${productId}/wish`, {
      body: JSON.stringify({ folderId })
    });
    if (res.status === 401) {
      throw Error(ERROR_MESSAGE.requiredLogin);
    }
    const { success, code, message }: DefaultResponse = await res.json();
    if (!res.ok || !success) throw new Error(ERROR_MESSAGE.api({ code, message }));
  }
  // ...
}



// 토스트 처리
const useAddWishProductMutation = () => {
  const { openToast } = useToast();
  // ...
  const onError = ({ message }: Error) => {
    switch (message) {
      case ERROR_MESSAGE.requiredLogin:
        openToast(<RequiredLoginToast />);
        break;

      default:
        openToast(
          <ToastPop>
            <div>{message}</div>
          </ToastPop>
        );
        break;
    }
  };

  return useMutation({ mutationFn, onSuccess, onError });
};
// ...

```

### 4. throw API Error
`throwApiError` deprecated 처리하고
`ERROR_MESSAGE.api()` 만들어뒀습니다.


```ts
      throw Error(ERROR_MESSAGE.api({code, message}));
```


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## To reviewers
