### PR TITLE
🐛 Fix :  상품 상세페이지 이미지 오류 해결 & title clamp, 디자인 수정

### DIFF
--- a/src/blocks/main/(detail)/products/[productId]/info/BoardImagesSection.tsx
+++ b/src/blocks/main/(detail)/products/[productId]/info/BoardImagesSection.tsx
@@ -16,18 +16,22 @@ const BoardImagesSection = ({ productId }: { productId: string }) => {
   const { data: boardDetail } = useGetBoardDetailQuery(productId);
   const { data: productOption } = useGetProductOptionQuery(productId);
 
+  const imageArray = [boardDetail?.profile, ...(boardDetail?.boardImages ?? [])].filter(
+    (item) => item !== undefined && item !== null
+  );
+
   return (
     <PaddingWrapper className="py-0">
       <div className="relative">
-        <ProductImageSlide boardImages={boardDetail?.boardImages} onChange={setSwiperIndex} />
+        <ProductImageSlide boardImages={imageArray as string[]} onChange={setSwiperIndex} />
         {productOption?.boardIsBundled && (
           <div className="absolute top-[10px] left-[10px] z-10 ">
             <BundleBadge />
           </div>
         )}
-        {boardDetail?.boardImages.length === 0 && (
+        {imageArray.length > 0 && (
           <div className="absolute bottom-[10px] right-[10px] w-[37px] h-[21px] px-2.5 py-0.5 bg-black bg-opacity-60 rounded-[50px] justify-center items-center gap-2.5 inline-flex z-10">
-            <ImageCounter index={swiperIndex} total={boardDetail?.boardImages.length} />
+            <ImageCounter index={swiperIndex} total={imageArray.length} />
           </div>
         )}
       </div>

--- a/src/blocks/main/(detail)/products/[productId]/info/ProductOptionsSection/OrderAvailableDays/BellButton.tsx
+++ b/src/blocks/main/(detail)/products/[productId]/info/ProductOptionsSection/OrderAvailableDays/BellButton.tsx
@@ -10,13 +10,11 @@ const BellButton = ({ isNotified }: { isNotified: boolean }) => {
     <button
       type="button"
       onClick={shake}
-      className="p-[6px] flex gap-[2px] border border-gray-200 rounded-[4px]"
+      className={`p-[6px] flex gap-[2px] border border-gray-200 rounded-[4px] ${isActive ? 'bg-gray-900' : 'bg-gray-50'}`}
     >
-      <div className={isActive ? 'animate-bell' : ''}>
-        <BellIcons shape={isActive ? 'on' : 'off'} />
-      </div>
-      <span className="typo-body-12-medium text-gray-600">
-        빵켓팅 알림 {isActive ? '신청' : '해제'}
+      <div className={isActive ? 'animate-bell' : ''}>{isActive && <BellIcons shape="on" />}</div>
+      <span className={`typo-body-12-medium ${isActive ? 'text-white' : ' text-gray-600'}`}>
+        빵켓팅 알림 {isActive ? '중' : '신청'}
       </span>
     </button>
   );

--- a/src/domains/product/components/ProductCard/ProductImage/index.tsx
+++ b/src/domains/product/components/ProductCard/ProductImage/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MouseEventHandler, useState } from 'react';
+import { MouseEventHandler } from 'react';
 
 import Image from 'next/image';
 import { useRecoilValue } from 'recoil';
@@ -23,19 +23,15 @@ const ProductImage = ({ product, popular, ranking }: ProductImageProps) => {
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg==';
   const selectedWishFolder = useRecoilValue(selectedWishFolderState);
 
-  const [isLiked, setIsLiked] = useState(product.isWished);
-
   const { mutate: addMutate } = useAddWishProductMutation();
   const { mutate: deleteMutate } = useDeleteWishProductMutation();
 
   const like: MouseEventHandler<HTMLButtonElement> = (e) => {
-    setIsLiked((prev) => !prev);
     addMutate({ productId: product.boardId, folderId: selectedWishFolder });
     e.preventDefault();
   };
 
   const hate: MouseEventHandler<HTMLButtonElement> = (e) => {
-    setIsLiked((prev) => !prev);
     deleteMutate({ productId: product.boardId });
     e.preventDefault();
   };
@@ -49,10 +45,14 @@ const ProductImage = ({ product, popular, ranking }: ProductImageProps) => {
         height={300}
         placeholder="blur"
         blurDataURL={BLUR_DATA_URL}
-        className="rounded-[6px] aspect-square border-[1px] border-gray-100"
+        className="rounded-[6px] aspect-square"
       />
       <div className="absolute bottom-[9px] right-[9px] h-[20px]">
-        <HeartButton isActive={isLiked} shape="shadow" onClick={isLiked ? hate : like} />
+        <HeartButton
+          isActive={product.isWished}
+          shape="shadow"
+          onClick={product.isWished ? hate : like}
+        />
       </div>
       <div className="absolute z-10 top-[6px] left-[6px] w-full flex gap-[6px]">
         {popular && <RankingBadge ranking={ranking} />}

--- a/src/domains/product/queries/useGetBoardDetailQuery.ts
+++ b/src/domains/product/queries/useGetBoardDetailQuery.ts
@@ -7,7 +7,11 @@ const useGetBoardDetailQuery = (productId: string) => {
   const queryKey = [QUERY_KEY.boardDetail];
   const queryFn = () => productService.getBoardDetail(productId);
 
-  return useQuery({ queryKey, queryFn });
+  return useQuery({
+    queryKey,
+    queryFn,
+    staleTime: 0
+  });
 };
 
 export default useGetBoardDetailQuery;

--- a/src/domains/product/queries/useGetBoardDetailQuery.ts
+++ b/src/domains/product/queries/useGetBoardDetailQuery.ts
@@ -4,13 +4,12 @@ import { useQuery } from '@tanstack/react-query';
 import productService from './service';
 
 const useGetBoardDetailQuery = (productId: string) => {
-  const queryKey = [QUERY_KEY.boardDetail];
+  const queryKey = [QUERY_KEY.boardDetail, productId];
   const queryFn = () => productService.getBoardDetail(productId);
 
   return useQuery({
     queryKey,
-    queryFn,
-    staleTime: 0
+    queryFn
   });
 };
 

--- a/src/global/Footer.tsx
+++ b/src/global/Footer.tsx
@@ -34,7 +34,7 @@ const Footer = () => {
       href: PATH.search
     },
     {
-      title: '전체',
+      title: '카테고리',
       defaultIcon: <CategoryIcon />,
       activeIcon: <CategoryRedIcon />,
       href: PATH.mainCategory

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import React from 'react';
+
 import { twMerge } from 'tailwind-merge';
+
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
+
 import ArrowIcons from '../icons/ArrowIcons';
 
 interface HeaderProps {
@@ -29,8 +32,8 @@ const Header = ({ title, content, back = false, className }: HeaderProps) => {
           <ArrowIcons shape="back" />
         </button>
       )}
-      <div className="flex justify-between items-center w-full">
-        <h2 className="typo-title-16-medium">{title}</h2>
+      <div className="flex justify-between items-center w-full ">
+        <h2 className="typo-title-16-medium line-clamp-2">{title}</h2>
         {content}
       </div>
     </PaddingWrapper>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,7 @@ module.exports = {
 
       colors: {
         // ex) text-gray-50
+
         gray: {
           50: '#FAFAFA',
           100: '#F5F5F5',


### PR DESCRIPTION
## 이슈 번호

>  close #429 

## 작업 내용 및 테스트 방법

> 
### 1. 상품 상세페이지 boardImage 수정

#### 1-1. 이미지 데이터를 최신꺼로 사용하지 않는 버그
- 상세페이지 접속 후 다른 상품의 상세페이지를 접속했을 시 첫 상품의 상세 이미지를 사용하는 문제가 존재
- staleTime:0 으로 해결
- 하지만 아래 영상처럼 페이지 최초 접속과 동시에 이전이미지가 깜빡이며 잠깐 렌더링 되고 있습니다ㅠㅠ 다른 부분 작업하시며 이 부분 경험하신 분 계신가요?


#### 1-2. 상품 상세 이미지 데이터 변경
- 기존 : boardImages만 보여줌
- 변경 후: boardImages + profile을 합친 새로운 배열을 만듬 => boardImages가 null이면 profile을 보여주게 됨
<img width="561" alt="image" src="https://github.com/eco-dessert-platform/dessert-front/assets/103630185/f10b416c-29c3-4c9e-9b14-d200fb88b7f9">


### 2. Header 컴포넌트 title 2줄 제한
- 2줄이 넘어가면 ...으로 말줄임하도록 설정하였습니다
<img width="262" alt="image" src="https://github.com/eco-dessert-platform/dessert-front/assets/103630185/349b1a08-75ee-42fb-a398-12cd0a8881cf">


### 3. 바뀐 빵켓팅 디자인 수정
빵켓팅 신청, 해제 의 디자인 변경 사항 적용하였습니다



## To reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- 보드 이미지 처리 개선 및 유효한 이미지만 표시하도록 업데이트.
	- 버튼 상태에 따라 동적으로 배경색 변경 및 텍스트 업데이트.
	- '좋아요' 기능을 단순화하여 제품 상태에 직접 연결.
	- 네비게이션 메뉴 항목의 텍스트 변경으로 사용자 이해도 향상.
	- 헤더 제목의 텍스트 오버플로우 조절.

- **Bug Fixes**
	- 이미지 카운터와 보드 이미지 동기화 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->