### PR TITLE
🐛 Fix :  찜 버그

### DIFF
--- a/src/app/main/(detail)/products/[productId]/layout.tsx
+++ b/src/app/main/(detail)/products/[productId]/layout.tsx
@@ -44,7 +44,7 @@ const DetailInfoLayout = async ({ params, children }: DetailInfoLayoutProps) => 
       />
       <ProductDetailTabs />
       {children}
-      <FixedPurchaseButtonSection boardData={boardData} />
+      <FixedPurchaseButtonSection />
     </HydrationBoundary>
   );
 };

--- a/src/blocks/main/(detail)/products/[productId]/info/FixedPurchaseButtonSection.tsx
+++ b/src/blocks/main/(detail)/products/[productId]/info/FixedPurchaseButtonSection.tsx
@@ -4,22 +4,23 @@ import { MouseEventHandler } from 'react';
 
 import { useRecoilValue } from 'recoil';
 
-import { IBoardDetailType } from '@/domains/product/types/productDetailType';
 import { selectedWishFolderState } from '@/domains/wish/atoms/wishFolder';
 import useAddWishProductMutation from '@/domains/wish/queries/useAddWishProductMutation';
 import useDeleteWishProductMutation from '@/domains/wish/queries/useDeleteWishProductMutation';
 import HeartButton from '@/shared/components/HeartButton';
 import ButtonNewver from '@/shared/components/ButtonNewver';
+import useGetBoardDetailQuery from '@/domains/product/queries/useGetBoardDetailQuery';
+import { useParams } from 'next/navigation';
 
-interface DetailFixedBtnSectionProps {
-  boardData: IBoardDetailType;
-}
-
-const FixedPurchaseButtonSection = ({ boardData }: DetailFixedBtnSectionProps) => {
+const FixedPurchaseButtonSection = () => {
+  const { productId } = useParams<{ productId: string }>();
   const selectedWishFolder = useRecoilValue(selectedWishFolderState);
 
   const { mutate: addMutate } = useAddWishProductMutation();
   const { mutate: deleteMutate } = useDeleteWishProductMutation();
+  const { data: boardData } = useGetBoardDetailQuery(productId);
+
+  if (!boardData) return 'data not found';
 
   const addToWishlist: MouseEventHandler<HTMLButtonElement> = (e) => {
     addMutate({ productId: boardData.id, folderId: selectedWishFolder });

--- a/src/domains/wish/queries/useAddWishProductMutation.tsx
+++ b/src/domains/wish/queries/useAddWishProductMutation.tsx
@@ -36,7 +36,7 @@ const useAddWishProductMutation = () => {
 
   const onSuccess = ({ productId }: { productId: number }) => {
     queryClient.invalidateQueries({ queryKey: wishQueryKey.folders() });
-    queryClient.invalidateQueries({ queryKey: productQueryKey.detail(productId) });
+    queryClient.invalidateQueries({ queryKey: productQueryKey.detail(productId, 'board-detail') });
 
     const openFolderSelectModal = () => openModal(<WishFolderSelectModal productId={productId} />);
     openToast({

--- a/src/domains/wish/queries/useMoveWishProduct.tsx
+++ b/src/domains/wish/queries/useMoveWishProduct.tsx
@@ -1,16 +1,16 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import useToastNewVer from '@/shared/hooks/useToastNewVer';
 import useModal from '@/shared/hooks/useModal';
-import { revalidatePath } from '@/shared/actions/revalidate';
-import PATH from '@/shared/constants/path';
 import wishService from './service';
 /** 기획상 순환이 발생 */
 // eslint-disable-next-line import/no-cycle
 import WishFolderSelectModal from '../components/alert-box/WishFolderSelectModal';
+import { wishQueryKey } from './queryKey';
 
 const useMoveWishProduct = () => {
   const { openToast } = useToastNewVer();
   const { openModal, closeModal } = useModal();
+  const queryClient = useQueryClient();
 
   const mutationFn = async ({
     productId,
@@ -27,9 +27,10 @@ const useMoveWishProduct = () => {
   };
 
   const onSuccess = ({ productId, folderName }: { productId: number; folderName: string }) => {
-    revalidatePath(PATH.wishProductList);
     const openFolderSelectModal = () => openModal(<WishFolderSelectModal productId={productId} />);
     closeModal();
+    queryClient.invalidateQueries({ queryKey: wishQueryKey.folders() });
+
     openToast({
       message: `${folderName}에 추가했어요`,
       action: (


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 찜 폴더 변경후 invalidate 안되는 버그 수정
2. product detail 페이지 아래 찜 버튼 버그 수정
 - 백엔드에서도 버그가 있어서 아직 해결 안되었어요.

## To reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선된 기능**
  - `FixedPurchaseButtonSection` 컴포넌트에서 `boardData` prop가 제거되어, 내부 상태를 활용하여 데이터를 처리하게 됨.
  - 데이터가 없을 경우 사용자에게 피드백을 제공하는 조건부 렌더링 기능이 추가됨.
  - `useMoveWishProduct` 훅이 쿼리 상태 관리를 개선하여, 위시 리스트의 제품 이동 후 인터페이스가 즉시 업데이트됨.

- **버그 수정**
  - 제품을 위시 리스트에 추가할 때 쿼리 무효화가 보다 구체적으로 처리되어 데이터 업데이트의 정확성을 향상시킴.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->