### PR TITLE
🐛 Fix :  비로그인 시에는 하트 비활성화 시키기

### DIFF
--- a/src/domains/wish/queries/useAddWishProductMutation.tsx
+++ b/src/domains/wish/queries/useAddWishProductMutation.tsx
@@ -1,19 +1,21 @@
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
-import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { IProductType } from '@/domains/product/types/productType';
+import { IStoreProductType } from '@/domains/store/types/store';
+import { isLoggedinState } from '@/shared/atoms/login';
+import { ERROR_MESSAGE } from '@/shared/constants/error';
+import PATH from '@/shared/constants/path';
 import useModal from '@/shared/hooks/useModal';
 import useToastNewVer from '@/shared/hooks/useToastNewVer';
-import { ERROR_MESSAGE } from '@/shared/constants/error';
-import { isLoggedinState } from '@/shared/atoms/login';
-import PATH from '@/shared/constants/path';
 import { productQueryKey, storeQueryKey } from '@/shared/queries/queryKey';
-import { IProductType } from '@/domains/product/types/productType';
 import { Cursor } from '@/shared/types/response';
-import { IStoreProductType } from '@/domains/store/types/store';
-import wishService from './service';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateInfiniteQueryCache } from '../../../shared/utils/queryCache';
 import WishFolderSelectModal from '../components/alert-box/WishFolderSelectModal';
 import { wishQueryKey } from './queryKey';
-import { updateInfiniteQueryCache } from '../../../shared/utils/queryCache';
+import wishService from './service';
 
 const useAddWishProductMutation = () => {
   const { openToast } = useToastNewVer();
@@ -28,6 +30,8 @@ const useAddWishProductMutation = () => {
   };
 
   const onMutate = ({ productId }: { productId: number }) => {
+    if (!isLoggedIn) return;
+
     queryClient.setQueriesData<InfiniteData<Cursor<IProductType[]>>>(
       { queryKey: productQueryKey.all },
       (oldData) =>


### PR DESCRIPTION
## 이슈 번호

> 

## 작업 내용 및 테스트 방법

> 
-  useAddWishProductMutation에서 비로그인 시 찜 버튼 active 되는 문제 해결하였습니다

## To reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자가 로그인한 경우에만 위시 제품 추가를 허용하는 새로운 인증 체크 기능이 추가되었습니다.
  
- **버그 수정**
	- 사용자 인증 상태에 따라 위시 제품 추가 기능의 흐름을 개선하여 보안성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->