### PR TITLE
🐛 Fix :  리뷰 없을때 UI 구현

### DIFF
--- a/src/app/(with-navigation)/mypage/review/_blocks/ReviewList.tsx
+++ b/src/app/(with-navigation)/mypage/review/_blocks/ReviewList.tsx
@@ -2,6 +2,7 @@
 
 import Review from '@/domains/review/components/Review';
 import useMyReviewQuery from '@/domains/review/queries/useMyReviewQuery';
+import SadBbangleBox from '@/shared/components/SadBbangleBox';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
@@ -12,6 +13,9 @@ const ReviewList = () => {
   useEffect(() => {
     if (inView) fetchNextPage();
   }, [inView, fetchNextPage]);
+
+  if (!reviews || reviews.length === 0)
+    return <SadBbangleBox className="absoulte-center">작성된 리뷰가 없어요.</SadBbangleBox>;
 
   return (
     <section className="flex flex-col divide-y divide-gray-200">

--- a/src/app/main/products/[productId]/review/_blocks/ReviewList.tsx
+++ b/src/app/main/products/[productId]/review/_blocks/ReviewList.tsx
@@ -2,6 +2,7 @@
 
 import Review from '@/domains/review/components/Review';
 import useReviewQuery from '@/domains/review/queries/useReviewQuery';
+import SadBbangleBox from '@/shared/components/SadBbangleBox';
 import Skeleton from '@/shared/components/Skeleton';
 import { useParams } from 'next/navigation';
 import { useEffect } from 'react';
@@ -15,6 +16,9 @@ const ReviewList = () => {
   useEffect(() => {
     if (inView) fetchNextPage();
   }, [inView, fetchNextPage]);
+
+  if (!reviews || reviews.length === 0)
+    return <SadBbangleBox className="size-[300px] mx-auto">작성된 리뷰가 없어요.</SadBbangleBox>;
 
   return (
     <section className="flex flex-col divide-y divide-gray-200">

--- a/src/app/main/products/[productId]/review/page.tsx
+++ b/src/app/main/products/[productId]/review/page.tsx
@@ -42,9 +42,9 @@ const ReviewListPage = async ({ params }: Props) => {
         >
           리뷰 작성
         </Link>
-        {bestReview.images && bestReview.images.length > 0 && (
+        {bestReview?.images && bestReview.images.length > 0 && (
           <div className="flex gap-[4px] w-full aspect-[4/1]">
-            {bestReview.images.slice(0, 4).map(({ id, url }, idx) => (
+            {bestReview?.images.slice(0, 4).map(({ id, url }, idx) => (
               <div
                 key={id}
                 className={cn(


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

리뷰 없을 때 UI 구현했습니다.

<img width="603" alt="스크린샷 2024-09-18 오후 2 42 43" src="https://github.com/user-attachments/assets/bf8ce656-996f-46c9-aaa2-313d9ce10b89">

<img width="595" alt="스크린샷 2024-09-18 오후 2 42 58" src="https://github.com/user-attachments/assets/71d465d1-ba9e-413c-88f7-24e7944304a4">

## To reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 리뷰가 없을 경우 사용자에게 적절한 메시지를 제공하는 기능 추가.
- **버그 수정**
	- `bestReview` 객체의 `images` 속성 접근 시 오류 방지를 위한 선택적 체이닝 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->