### PR TITLE
✨ Feat :  카테고리 페이지 수정

### DIFF
--- a/src/app/(with-navigation)/main/products/layout.tsx
+++ b/src/app/(with-navigation)/main/products/layout.tsx
@@ -1,19 +1,12 @@
 'use client';
 
-import { useRecoilValue } from 'recoil';
-
-import { mainCategoryState } from '@/domains/product/atoms';
-import { FILTER_FAMILY_ID } from '@/domains/product/constants/filterFamilyID';
 import Header from '@/shared/components/Header';
 
-const MainListLayout = ({ children }: { children: React.ReactNode }) => {
-  const mainCategory = useRecoilValue(mainCategoryState(FILTER_FAMILY_ID.main));
-  return (
-    <>
-      <Header title={mainCategory} back />
-      {children}
-    </>
-  );
-};
+const MainListLayout = ({ children }: { children: React.ReactNode }) => (
+  <>
+    <Header title="카테고리" back />
+    {children}
+  </>
+);
 
 export default MainListLayout;

--- a/src/domains/product/components/CategoryItemSection/SubCategoryList/SubCategoryItem.tsx
+++ b/src/domains/product/components/CategoryItemSection/SubCategoryList/SubCategoryItem.tsx
@@ -3,6 +3,7 @@ import { useSetRecoilState } from 'recoil';
 
 import { filterValueState } from '@/domains/product/atoms';
 import { FILTER_FAMILY_ID } from '@/domains/product/constants/filterFamilyID';
+import { INIT_FILTER_VALUE } from '@/domains/product/constants/filterValues';
 import useCategory from '@/domains/product/hooks/useCategory';
 import ArrowIcons from '@/shared/components/icons/ArrowIcons';
 import PATH from '@/shared/constants/path';
@@ -16,7 +17,7 @@ const SubCategoryItem = ({ categoryItem }: SubCategoryItemProps) => {
   const { elaborateCategory } = useCategory(FILTER_FAMILY_ID.main);
 
   const clickCategory = (selectedItem: string) => {
-    setFilterValue((prev) => ({ ...prev, category: elaborateCategory(selectedItem) }));
+    setFilterValue({ ...INIT_FILTER_VALUE, category: elaborateCategory(selectedItem) });
   };
 
   return (

--- a/src/domains/product/components/CategoryItemSection/index.tsx
+++ b/src/domains/product/components/CategoryItemSection/index.tsx
@@ -32,7 +32,7 @@ const CategoryItemSection = ({ shape, title, subCategories }: CategoryItemProps)
     toggle();
     setMainCategory(title);
     if (subCategories.length === 0) {
-      setFilterValue((prev) => ({ ...prev, category: INIT_FILTER_VALUE.category }));
+      setFilterValue(INIT_FILTER_VALUE);
       router.push(PATH.mainProductList);
     }
   };

--- a/src/domains/product/components/alert-box/FilterModal/ButtonSection.tsx
+++ b/src/domains/product/components/alert-box/FilterModal/ButtonSection.tsx
@@ -29,7 +29,7 @@ const ButtonSection = ({ filterFamilyId }: ButtonSectionProps) => {
   };
 
   return (
-    <PaddingWrapper className="flex gap-[10px] justify-center items-center">
+    <PaddingWrapper className="flex gap-[10px] justify-between items-center fixed bottom-0 w-full bg-white">
       <ButtonNewver
         color="border-white"
         size="lg"

--- a/src/domains/product/components/alert-box/FilterModal/IsOrderAvailableCheckbox.tsx
+++ b/src/domains/product/components/alert-box/FilterModal/IsOrderAvailableCheckbox.tsx
@@ -26,7 +26,7 @@ const IsOrderAvailableCheckbox = ({ filterFamilyId }: OrderAvailableCheckBoxProp
   };
 
   return (
-    <PaddingWrapper>
+    <PaddingWrapper className="mb-[100px]">
       <CheckBox
         className="text-gray-800 typo-title-14-regular"
         isChecked={orderAvailableToday}

--- a/src/domains/product/constants/filterValues.ts
+++ b/src/domains/product/constants/filterValues.ts
@@ -6,8 +6,9 @@ export const FILTER_VALUES = {
     name: '카테고리',
     kind: {
       [MAIN_CATEGORIES_TYPE[0].title]: [
-        ...MAIN_CATEGORIES_TYPE[1].subCategories,
-        ...MAIN_CATEGORIES_TYPE[2].subCategories.slice(1)
+        ...MAIN_CATEGORIES_TYPE[1].subCategories.filter((subCategory) => subCategory !== '기타'),
+        ...MAIN_CATEGORIES_TYPE[2].subCategories.slice(1),
+        '기타'
       ],
       [MAIN_CATEGORIES_TYPE[1].title]: MAIN_CATEGORIES_TYPE[1].subCategories,
       [MAIN_CATEGORIES_TYPE[2].title]: MAIN_CATEGORIES_TYPE[2].subCategories

--- a/src/domains/product/constants/mainCategories.tsx
+++ b/src/domains/product/constants/mainCategories.tsx
@@ -9,7 +9,7 @@ export const MAIN_CATEGORIES_TYPE = [
     id: 1,
     shape: 'bread',
     title: '빵',
-    subCategories: ['전체', '식빵·모닝빵', '베이글·도넛', '케이크', '타르트·파이']
+    subCategories: ['전체', '식빵·모닝빵', '베이글·도넛', '케이크', '타르트·파이', '기타']
   },
   {
     id: 2,
@@ -22,8 +22,7 @@ export const MAIN_CATEGORIES_TYPE = [
       '잼·청',
       '아이스크림',
       '요거트',
-      '그래놀라',
-      '기타'
+      '그래놀라'
     ]
   }
 ];


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 필터 모달 내 바텀 버튼 fixed
- 카테고리 페이지 헤더 타이틀 '카테고리'로 고정
- 간식/과자 카테고리에서 빵 카테고리로 '기타' 서브 카테고리 옮김
- 다른 카테고리로 이동 시, 이전에 설정한 필터 값 초기화

## To reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 헤더 제목을 "카테고리"로 고정하여 사용자에게 더 명확한 정보 제공.
	- 필터 상태 초기화 방식 변경으로 더 일관된 카테고리 선택 경험 제공.

- **버그 수정**
	- 하위 카테고리 필터링 로직 개선으로 사용자에게 더 정확한 카테고리 정보 제공.

- **스타일**
	- 버튼 섹션의 레이아웃 스타일 개선으로 버튼의 가시성 및 배치 향상.
	- 체크박스 컴포넌트의 여백 조정으로 시각적 일관성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->