### PR TITLE
🐛 Fix : 찜 버그 개선

### DIFF
--- a/src/blocks/main/(detail)/products/[productId]/info/SimpleInfoWithStoreSection/DetailStoreInfo.tsx
+++ b/src/blocks/main/(detail)/products/[productId]/info/SimpleInfoWithStoreSection/DetailStoreInfo.tsx
@@ -2,13 +2,17 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRecoilValue } from 'recoil';
 
-import HeartButton from '@/shared/components/HeartButton';
-import PaddingWrapper from '@/shared/components/PaddingWrapper';
-import PATH from '@/shared/constants/path';
+import { useGetStoreInfoQuery } from '@/domains/store/queries/useGetStoreInfoQuery';
 import useAddWishStoreMutation from '@/domains/wish/queries/useAddWishStoreMutation';
 import useDeleteWishStoreMutation from '@/domains/wish/queries/useDeleteWishStoreMutation';
-import { useGetStoreInfoQuery } from '@/domains/store/queries/useGetStoreInfoQuery';
+import { isLoggedinState } from '@/shared/atoms/login';
+import HeartButton from '@/shared/components/HeartButton';
+import PaddingWrapper from '@/shared/components/PaddingWrapper';
+import { ERROR_MESSAGE } from '@/shared/constants/error';
+import PATH from '@/shared/constants/path';
+import useToastNewVer from '@/shared/hooks/useToastNewVer';
 
 interface Props {
   storeId: number;
@@ -18,13 +22,19 @@ const DetailStoreInfo = ({ storeId }: Props) => {
   const { data: storeData } = useGetStoreInfoQuery({ storeId });
   const { mutate: addMutate } = useAddWishStoreMutation(storeId);
   const { mutate: deleteMutate } = useDeleteWishStoreMutation(storeId);
+  const isLoggedIn = useRecoilValue(isLoggedinState);
+  const { openToast } = useToastNewVer();
 
   if (!storeData) return <PaddingWrapper>스토어 정보를 찾을 수 없어요.</PaddingWrapper>;
 
   const wishMutate = storeData.isWished ? deleteMutate : addMutate;
 
   const handleWish = (e: React.MouseEvent<HTMLButtonElement>) => {
-    wishMutate();
+    if (isLoggedIn) {
+      wishMutate();
+    } else {
+      openToast({ message: ERROR_MESSAGE.requiredLogin });
+    }
     e.preventDefault();
   };
 

--- a/src/domains/product/components/ProductCard/ProductImage/index.tsx
+++ b/src/domains/product/components/ProductCard/ProductImage/index.tsx
@@ -8,13 +8,13 @@ import { IProductType } from '@/domains/product/types/productType';
 import { selectedWishFolderState } from '@/domains/wish/atoms/wishFolder';
 import useAddWishProductMutation from '@/domains/wish/queries/useAddWishProductMutation';
 import useDeleteWishProductMutation from '@/domains/wish/queries/useDeleteWishProductMutation';
-import HeartButton from '@/shared/components/HeartButton';
 import Badge from '@/shared/components/Badge';
+import HeartButton from '@/shared/components/HeartButton';
 import { BellIcon } from '@/shared/components/icons';
-import { cn } from '@/shared/utils/cn';
-import { BLUR_DATA_URL } from '@/shared/constants/blurDataUrl';
 import ImageWithFallback from '@/shared/components/ImageWithFallback';
 import SadBbangleBox from '@/shared/components/SadBbangleBox';
+import { BLUR_DATA_URL } from '@/shared/constants/blurDataUrl';
+import { cn } from '@/shared/utils/cn';
 
 interface ProductImageProps {
   product: IProductType;
@@ -58,8 +58,8 @@ const ProductImage = ({
           className="object-cover rounded-[6px]"
           fill
           fallback={
-            <SadBbangleBox className="border rounded-[6px] size-full">
-              이미지를 불러오지 못 했어요.
+            <SadBbangleBox className="border bg-gray-50  rounded-[6px] size-full">
+              이미지가 없습니다.
             </SadBbangleBox>
           }
         />

--- a/src/domains/product/components/ProductCard/ProductImage/index.tsx
+++ b/src/domains/product/components/ProductCard/ProductImage/index.tsx
@@ -8,6 +8,7 @@ import { IProductType } from '@/domains/product/types/productType';
 import { selectedWishFolderState } from '@/domains/wish/atoms/wishFolder';
 import useAddWishProductMutation from '@/domains/wish/queries/useAddWishProductMutation';
 import useDeleteWishProductMutation from '@/domains/wish/queries/useDeleteWishProductMutation';
+import { isLoggedinState } from '@/shared/atoms/login';
 import Badge from '@/shared/components/Badge';
 import HeartButton from '@/shared/components/HeartButton';
 import { BellIcon } from '@/shared/components/icons';
@@ -31,8 +32,12 @@ const ProductImage = ({
   const { mutate: addMutate } = useAddWishProductMutation();
   const { mutate: deleteMutate } = useDeleteWishProductMutation();
 
+  const isLoggedIn = useRecoilValue(isLoggedinState);
+
   const like: MouseEventHandler<HTMLButtonElement> = (e) => {
-    addMutate({ productId: boardId, folderId: selectedWishFolder });
+    if (isLoggedIn) {
+      addMutate({ productId: boardId, folderId: selectedWishFolder });
+    }
     e.preventDefault();
   };
 

--- a/src/domains/product/components/ProductCard/ProductImage/index.tsx
+++ b/src/domains/product/components/ProductCard/ProductImage/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useState } from 'react';
 
 import { useRecoilValue } from 'recoil';
 
@@ -15,6 +15,8 @@ import { BellIcon } from '@/shared/components/icons';
 import ImageWithFallback from '@/shared/components/ImageWithFallback';
 import SadBbangleBox from '@/shared/components/SadBbangleBox';
 import { BLUR_DATA_URL } from '@/shared/constants/blurDataUrl';
+import { ERROR_MESSAGE } from '@/shared/constants/error';
+import useToastNewVer from '@/shared/hooks/useToastNewVer';
 import { cn } from '@/shared/utils/cn';
 
 interface ProductImageProps {
@@ -28,7 +30,8 @@ const ProductImage = ({
   ranking
 }: ProductImageProps) => {
   const selectedWishFolder = useRecoilValue(selectedWishFolderState);
-
+  const { openToast } = useToastNewVer();
+  const [isPopping, setIsPopping] = useState(false);
   const { mutate: addMutate } = useAddWishProductMutation();
   const { mutate: deleteMutate } = useDeleteWishProductMutation();
 
@@ -37,12 +40,16 @@ const ProductImage = ({
   const like: MouseEventHandler<HTMLButtonElement> = (e) => {
     if (isLoggedIn) {
       addMutate({ productId: boardId, folderId: selectedWishFolder });
+      setIsPopping(true);
+    } else {
+      openToast({ message: ERROR_MESSAGE.requiredLogin });
     }
     e.preventDefault();
   };
 
   const hate: MouseEventHandler<HTMLButtonElement> = (e) => {
     deleteMutate({ productId: boardId });
+    setIsPopping(false);
     e.preventDefault();
   };
 
@@ -69,9 +76,13 @@ const ProductImage = ({
           }
         />
       </div>
-
-      <div className="absolute z-10 bottom-[9px] right-[9px] h-[20px]">
-        <HeartButton isActive={isWished} shape="shadow" onClick={isWished ? hate : like} />
+      <div className="absolute z-10 bottom-[9px] right-[9px] h-[20px] ">
+        <HeartButton
+          isActive={isWished}
+          className={isPopping ? 'animate-heart-pop' : ''}
+          shape="shadow"
+          onClick={isWished ? hate : like}
+        />
       </div>
       <div className="absolute z-10 top-[6px] left-[6px] w-full flex flex-wrap gap-[6px]">
         {popular && <Badge type="ranking">{ranking}</Badge>}

--- a/src/domains/wish/queries/useAddWishProductMutation.tsx
+++ b/src/domains/wish/queries/useAddWishProductMutation.tsx
@@ -1,19 +1,21 @@
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
-import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { IProductType } from '@/domains/product/types/productType';
+import { IStoreProductType } from '@/domains/store/types/store';
+import { isLoggedinState } from '@/shared/atoms/login';
+import { ERROR_MESSAGE } from '@/shared/constants/error';
+import PATH from '@/shared/constants/path';
 import useModal from '@/shared/hooks/useModal';
 import useToastNewVer from '@/shared/hooks/useToastNewVer';
-import { ERROR_MESSAGE } from '@/shared/constants/error';
-import { isLoggedinState } from '@/shared/atoms/login';
-import PATH from '@/shared/constants/path';
 import { productQueryKey, storeQueryKey } from '@/shared/queries/queryKey';
-import { IProductType } from '@/domains/product/types/productType';
 import { Cursor } from '@/shared/types/response';
-import { IStoreProductType } from '@/domains/store/types/store';
-import wishService from './service';
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateInfiniteQueryCache } from '../../../shared/utils/queryCache';
 import WishFolderSelectModal from '../components/alert-box/WishFolderSelectModal';
 import { wishQueryKey } from './queryKey';
-import { updateInfiniteQueryCache } from '../../../shared/utils/queryCache';
+import wishService from './service';
 
 const useAddWishProductMutation = () => {
   const { openToast } = useToastNewVer();
@@ -65,8 +67,12 @@ const useAddWishProductMutation = () => {
     openToast({
       message: '💖 찜한 상품에 추가했어요',
       action: (
-        <button type="button" className="hover:underline" onClick={openFolderSelectModal}>
-          편집
+        <button
+          type="button"
+          className="typo-body-12-regular-underline "
+          onClick={openFolderSelectModal}
+        >
+          수정
         </button>
       )
     });

--- a/src/shared/components/ToastPop/index.tsx
+++ b/src/shared/components/ToastPop/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { motion } from 'framer-motion';
 import { ReactNode } from 'react';
+
+import { motion } from 'framer-motion';
 
 interface Props {
   children?: ReactNode;
@@ -28,7 +29,7 @@ const ToastPop = ({ children, index = 0, action }: Props) => {
         translateY: `${-100 - TRANS_Y_RATIO * index}%`,
         opacity: 0
       }}
-      className="absolute w-full shadow-[0px_0px_10px_0px_rgba(0,0,0,0.3)] flex items-center justify-between  px-[16px] py-[10px]  bg-gray-800 rounded-[8px] text-white typo-title-14-medium"
+      className="absolute w-[92%] mx-[16px] shadow-[0px_0px_10px_0px_rgba(0,0,0,0.3)] flex items-center justify-between  px-[16px] py-[10px]  bg-gray-800 rounded-[8px] text-white typo-title-14-medium"
     >
       <span>{children}</span>
       {action && <span>{action}</span>}


### PR DESCRIPTION
## 이슈 번호

> 

## 작업 내용 및 테스트 방법

>

## 1.스토어 찜 버그
- 위치 : 상품 상세페이지 내의 DetailStoreInfo
- 기존 문제 : 프론트에서 로그인 시 찜이 가능하게 설계하여 백에서 주는 에러메세지를 토스트창에서 보여주게 됨 => 비로그인 상태에서 찜 시도 시 토스트창에 에러 발생

- 해결 방안 : 
isLoggedIn으로 조건문 추가
```html
  const handleWish = (e: React.MouseEvent<HTMLButtonElement>) => {
    wishMutate();
    if (isLoggedIn) {
      wishMutate();
    } else {
      openToast({ message: ERROR_MESSAGE.requiredLogin });
    }
 ```

## 2. 상품 찜 버그
- 위치 : ProductCard의 ProductImage
- 기존 문제 : 비로그인 시에는 상품 찜이 불가능해야함. 프론트에서 찜 비로그인 시 찜 기능은 안되도록 막아놓았지만 UI적으로 하트는 활성화되는 문제가 존재했음
- 해결 : 스토어 찜과 마찬가지로 like함수 내에서 비로그인 시에는 addMutate을 못하도록 설정

## 3. 디자인 수정
#### 토스트창의 width값 조정
- 이유 : 모바일 사이즈에서 보면 토스트창의 너비가 화면에 꽉차기 때문
<img width="465" alt="image" src="https://github.com/user-attachments/assets/e1559006-eb2b-4c8b-b121-23deacf07441">

#### 사라졌던 하트 뾰뵹 효과 추가
- ProductImage 내에 `const [isPopping, setIsPopping] = useState(false);` 이라는 isPopping state을 만들어서 **like** 시 `true`, **hate** 시 `false` 되도록 변경하여 구현
- 이유 : 디자인팀 요구사항
#### 상품 찜 성공 시 뜨는 토스트창의 "편집" 키워드를 "수정" 으로 변경
- 이유 : 디자인팀 요구사항

## To reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 사용자가 로그인 상태인지 확인 후 위시리스트에 제품 추가 기능 개선.
	- 로그인하지 않은 경우, 알림 메시지 표시.
	- 제품 이미지에 애니메이션 효과 추가 및 이미지가 없을 때의 메시지 수정.
	- 위시리스트에 제품 추가 후 폴더 선택 모달 표시.

- **버그 수정**
	- 토스트 알림의 버튼 텍스트 일관성 유지.

- **스타일**
	- 토스트 알림의 스타일 및 레이아웃 조정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->