### PR TITLE
✨ Feat :  상품 상세 페이지 이미지 슬라이드 화살표 추가

### DIFF
--- a/src/blocks/main/(detail)/products/[productId]/info/BoardImagesSection.tsx
+++ b/src/blocks/main/(detail)/products/[productId]/info/BoardImagesSection.tsx
@@ -28,7 +28,7 @@ const BoardImagesSection = ({ productId }: { productId: number }) => {
       <div className="relative">
         {haveBoardImages ? (
           <ProductImageSlide
-            boardImages={imageArray as string[]}
+            boardImages={imageArray}
             isSoldOut={isAllProductSoldOut}
             onChange={setSwiperIndex}
           />

--- a/src/blocks/main/(detail)/products/[productId]/info/FixedPurchaseButtonSection.tsx
+++ b/src/blocks/main/(detail)/products/[productId]/info/FixedPurchaseButtonSection.tsx
@@ -8,9 +8,10 @@ import { selectedWishFolderState } from '@/domains/wish/atoms/wishFolder';
 import useAddWishProductMutation from '@/domains/wish/queries/useAddWishProductMutation';
 import useDeleteWishProductMutation from '@/domains/wish/queries/useDeleteWishProductMutation';
 import HeartButton from '@/shared/components/HeartButton';
-import ButtonNewver from '@/shared/components/ButtonNewver';
+import ButtonNewver, { buttonVariants } from '@/shared/components/ButtonNewver';
 import useGetBoardDetailQuery from '@/domains/product/queries/useGetBoardDetailQuery';
 import { useParams } from 'next/navigation';
+import { cn } from '@/shared/utils/cn';
 
 const FixedPurchaseButtonSection = () => {
   const { productId } = useParams<{ productId: string }>();
@@ -38,13 +39,15 @@ const FixedPurchaseButtonSection = () => {
 
   return (
     <div className="bg-white max-w-[600px] w-full mx-auto p-[16px] flex items-center gap-[10px]">
-      <div>
-        <HeartButton
-          shape="default"
-          isActive={boardData.isWished}
-          onClick={boardData.isWished ? deleteToWishlist : addToWishlist}
-        />
-      </div>
+      <HeartButton
+        shape="default"
+        isActive={boardData.isWished}
+        onClick={boardData.isWished ? deleteToWishlist : addToWishlist}
+        className={cn(
+          buttonVariants({ size: 'lg', color: 'border-white', radius: 'round' }),
+          'min-w-max w-[56px] p-0'
+        )}
+      />
       <div className="flex-1">
         <ButtonNewver color="black" className="w-full" size="lg" onClick={gotoPurchaseUrl}>
           구매하러 가기

--- a/src/domains/product/components/ProductImageSlide/index.tsx
+++ b/src/domains/product/components/ProductImageSlide/index.tsx
@@ -1,51 +1,76 @@
 import 'swiper/css';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation } from 'swiper/modules';
 import { cn } from '@/shared/utils/cn';
 import { BLUR_DATA_URL } from '@/shared/constants/blurDataUrl';
 import ImageWithFallback from '@/shared/components/ImageWithFallback';
 import SadBbangleBox from '@/shared/components/SadBbangleBox';
+import { ArrowIcon } from '@/shared/components/icons';
 
 interface ImgSliderProps {
-  boardImages?: string[];
+  boardImages: string[];
   isSoldOut?: boolean;
   onChange: (_: number) => void;
 }
 
-const ProductImageSlide = ({ boardImages, isSoldOut, onChange }: ImgSliderProps) => (
-  <Swiper
-    spaceBetween={10}
-    slidesPerView={1}
-    pagination={{ clickable: true }}
-    scrollbar={{ el: '.swiper-scrollbar', draggable: true }}
-    onActiveIndexChange={(swiperCore) => {
-      onChange(swiperCore.activeIndex);
-    }}
-    className="w-full aspect-square"
-  >
-    {boardImages?.map((image) => (
-      <SwiperSlide
-        key={image}
-        className={cn(
-          'relative size-full',
-          isSoldOut &&
-            "after:content-['Sold_Out'] after:size-full after:flex-center after:absolute after:inset-0 after:bg-black/[0.3] after:text-gray-300 after:text-[40px] after:font-semibold after:rounded-[4px]"
-        )}
+const ProductImageSlide = ({ boardImages, isSoldOut, onChange }: ImgSliderProps) => {
+  const isMultipleImages = boardImages.length > 1;
+
+  return (
+    <Swiper
+      spaceBetween={10}
+      slidesPerView={1}
+      modules={[Navigation]}
+      scrollbar={{ el: '.swiper-scrollbar', draggable: true }}
+      navigation={{
+        nextEl: '.swiper-button-next',
+        prevEl: '.swiper-button-prev'
+      }}
+      onActiveIndexChange={(swiperCore) => {
+        onChange(swiperCore.activeIndex);
+      }}
+      className="w-full aspect-square"
+    >
+      {boardImages?.map((image) => (
+        <SwiperSlide
+          key={image}
+          className={cn(
+            'relative size-full',
+            isSoldOut &&
+              "after:content-['Sold_Out'] after:size-full after:flex-center after:absolute after:inset-0 after:bg-black/[0.3] after:text-gray-300 after:text-[40px] after:font-semibold after:rounded-[4px]"
+          )}
+        >
+          <ImageWithFallback
+            src={image}
+            alt="상품 이미지"
+            placeholder="blur"
+            blurDataURL={BLUR_DATA_URL}
+            fill
+            className="size-full rounded-[4px] object-cover"
+            fallback={
+              <SadBbangleBox className="border rounded-[4px] size-full">
+                이미지를 불러오지 못 했어요.
+              </SadBbangleBox>
+            }
+          />
+        </SwiperSlide>
+      ))}
+
+      <button
+        type="button"
+        aria-label="왼쪽 버튼"
+        className={cn('swiper-button-prev after:hidden invisible', isMultipleImages && 'visible')}
       >
-        <ImageWithFallback
-          src={image}
-          alt="상품 이미지"
-          placeholder="blur"
-          blurDataURL={BLUR_DATA_URL}
-          fill
-          className="size-full rounded-[4px] object-cover"
-          fallback={
-            <SadBbangleBox className="border rounded-[4px] size-full">
-              이미지를 불러오지 못 했어요.
-            </SadBbangleBox>
-          }
-        />
-      </SwiperSlide>
-    ))}
-  </Swiper>
-);
+        <ArrowIcon shape="left" />
+      </button>
+      <button
+        type="button"
+        aria-label="오른쪽 버튼"
+        className={cn('swiper-button-next after:hidden invisible', isMultipleImages && 'visible')}
+      >
+        <ArrowIcon shape="right" />
+      </button>
+    </Swiper>
+  );
+};
 export default ProductImageSlide;

--- a/src/domains/product/components/ProductImageSlide/index.tsx
+++ b/src/domains/product/components/ProductImageSlide/index.tsx
@@ -31,7 +31,7 @@ const ProductImageSlide = ({ boardImages, isSoldOut, onChange }: ImgSliderProps)
       }}
       className="w-full aspect-square"
     >
-      {boardImages?.map((image) => (
+      {boardImages.map((image) => (
         <SwiperSlide
           key={image}
           className={cn(


### PR DESCRIPTION
## 이슈 번호

> ex) #이슈번호

close #502 close #507

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 이미지 슬라이드 화살표 추가
- 상품 찜에 round border 추가
![image](https://github.com/user-attachments/assets/03a45fa2-c3c8-4443-ad91-98d84d416738)


## To reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 제품 이미지 슬라이드에 내비게이션 버튼 추가: 사용자가 여러 이미지를 쉽게 탐색할 수 있도록 개선됨.
	- 하트 버튼의 스타일링 옵션 향상: 버튼의 크기, 색상 및 반경에 따라 유연한 디자인 가능.
- **버그 수정**
	- `boardImages` 속성의 타입을 필수로 변경하여 이미지 URL 배열을 반드시 전달하도록 설정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->