### PR TITLE
🐛 Fix : 찜 페이지 개선

### DIFF
--- a/src/blocks/wish/(list)/products/WishFolderEditButtonSection.tsx
+++ b/src/blocks/wish/(list)/products/WishFolderEditButtonSection.tsx
@@ -6,11 +6,16 @@ import useModal from '@/shared/hooks/useModal';
 import { isWishFolderEditingState } from '@/domains/wish/atoms/wishFolder';
 import UpdateWishFolderModal from '@/domains/wish/components/alert-box/UpdateWishFolderModal';
 import useCreateWishFolderMutation from '@/domains/wish/queries/useCreateWishFolderMutation';
+import useWishFolderListQuery from '@/domains/wish/queries/useWishFolderListQuery';
+import { useMemo } from 'react';
 
 const WishFolderEditButtonSection = () => {
+  const { data: wishList } = useWishFolderListQuery();
   const { mutate: createFolderMutate } = useCreateWishFolderMutation();
   const [isEditing, setIsEditing] = useRecoilState(isWishFolderEditingState);
   const { openModal, closeModal } = useModal();
+
+  const isSingleFolder = useMemo(() => !wishList || wishList.length === 1, [wishList]);
 
   const editFolder = () => {
     setIsEditing(true);
@@ -36,11 +41,14 @@ const WishFolderEditButtonSection = () => {
       <Button variants="secondary-white" onClick={createFolder}>
         추가
       </Button>
-      {isEditing ? (
+
+      {!isSingleFolder && isEditing && (
         <Button variants="secondary-black" onClick={complete}>
           완료
         </Button>
-      ) : (
+      )}
+
+      {!isSingleFolder && !isEditing && (
         <Button variants="secondary-white" onClick={editFolder}>
           편집
         </Button>

--- a/src/blocks/wish/(list)/products/WishFolderEditButtonSection.tsx
+++ b/src/blocks/wish/(list)/products/WishFolderEditButtonSection.tsx
@@ -28,7 +28,6 @@ const WishFolderEditButtonSection = () => {
   const createFolder = () => {
     openModal(
       <UpdateWishFolderModal
-        prevTitle="NEW_FOLDER"
         onValidSubmit={({ title }) => {
           createFolderMutate(title);
           closeModal();

--- a/src/blocks/wish/(list)/products/WishFolderEditButtonSection.tsx
+++ b/src/blocks/wish/(list)/products/WishFolderEditButtonSection.tsx
@@ -28,6 +28,7 @@ const WishFolderEditButtonSection = () => {
   const createFolder = () => {
     openModal(
       <UpdateWishFolderModal
+        prevTitle="NEW_FOLDER"
         onValidSubmit={({ title }) => {
           createFolderMutate(title);
           closeModal();

--- a/src/domains/wish/components/WishFolder/index.tsx
+++ b/src/domains/wish/components/WishFolder/index.tsx
@@ -12,6 +12,7 @@ import { isWishFolderEditingState } from '../../atoms/wishFolder';
 import UpdateWishFolderModal from '../alert-box/UpdateWishFolderModal';
 import FolderThumbnail from '../common/FolderThumbnail';
 import useUpdateWishFolderMutation from '../../queries/useUpdateWishFolderMutation';
+import DefaultFolderAlertPopup from '../alert-box/DefaultFolderAlertPopup';
 
 interface WishFolderProps {
   id: number;
@@ -30,11 +31,21 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
   const isDefaultFolder = useMemo(() => DEFAULT_FOLDER_NAME === name, [name]);
 
   const deleteFolder: MouseEventHandler<HTMLButtonElement> = (e) => {
-    openPopup(<DeleteWishFolderPopup folderName={name} folderId={id} />);
     e.preventDefault();
+    if (isDefaultFolder) {
+      openPopup(<DefaultFolderAlertPopup />);
+      return;
+    }
+
+    openPopup(<DeleteWishFolderPopup folderName={name} folderId={id} />);
   };
 
   const updateFolderName: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isDefaultFolder) {
+      openPopup(<DefaultFolderAlertPopup />);
+      return;
+    }
+
     openModal(
       <UpdateWishFolderModal
         onValidSubmit={({ title }) => {
@@ -50,6 +61,8 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
         href={`${PATH.wishProductList}/${id}`}
         className="relative flex justify-center items-center after:pb-[100%] w-full"
       >
+        <FolderThumbnail thumbnailList={thumbnailList} />
+
         {!isDefaultFolder && isEditing && (
           <button
             aria-label="delete folder"
@@ -60,8 +73,6 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
             <CloseIcon shape="black" />
           </button>
         )}
-
-        <FolderThumbnail thumbnailList={thumbnailList} />
       </Link>
       <div className="flex justify-between items-center">
         {!isDefaultFolder && isEditing ? (

--- a/src/domains/wish/components/WishFolder/index.tsx
+++ b/src/domains/wish/components/WishFolder/index.tsx
@@ -13,6 +13,7 @@ import UpdateWishFolderModal from '../alert-box/UpdateWishFolderModal';
 import FolderThumbnail from '../common/FolderThumbnail';
 import useUpdateWishFolderMutation from '../../queries/useUpdateWishFolderMutation';
 import DefaultFolderAlertPopup from '../alert-box/DefaultFolderAlertPopup';
+import { DEFAULT_FOLDER_NAME } from '../../constants';
 
 interface WishFolderProps {
   id: number;
@@ -20,8 +21,6 @@ interface WishFolderProps {
   name: string;
   count: number;
 }
-
-const DEFAULT_FOLDER_NAME = '기본 폴더';
 
 const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
   const isEditing = useRecoilValue(isWishFolderEditingState);
@@ -48,6 +47,7 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
 
     openModal(
       <UpdateWishFolderModal
+        prevTitle={name}
         onValidSubmit={({ title }) => {
           updateWishFolderTitle({ title, folderId: id }, { onSuccess: closeModal });
         }}

--- a/src/domains/wish/components/WishFolder/index.tsx
+++ b/src/domains/wish/components/WishFolder/index.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRecoilValue } from 'recoil';
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useMemo } from 'react';
 import usePopup from '@/shared/hooks/usePopup';
 import useModal from '@/shared/hooks/useModal';
 import { CloseIcon } from '@/shared/components/icons';
@@ -20,11 +20,14 @@ interface WishFolderProps {
   count: number;
 }
 
+const DEFAULT_FOLDER_NAME = '기본 폴더';
+
 const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
   const isEditing = useRecoilValue(isWishFolderEditingState);
   const { openPopup } = usePopup();
   const { openModal } = useModal();
   const { mutate: updateWishFolderTitle } = useUpdateWishFolderMutation();
+  const isDefaultFolder = useMemo(() => DEFAULT_FOLDER_NAME === name, [name]);
 
   const deleteFolder: MouseEventHandler<HTMLButtonElement> = (e) => {
     openPopup(<DeleteWishFolderPopup folderName={name} folderId={id} />);
@@ -47,7 +50,7 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
         href={`${PATH.wishProductList}/${id}`}
         className="relative flex justify-center items-center after:pb-[100%] w-full"
       >
-        {isEditing && (
+        {!isDefaultFolder && isEditing && (
           <button
             aria-label="delete folder"
             type="button"
@@ -61,7 +64,7 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
         <FolderThumbnail thumbnailList={thumbnailList} />
       </Link>
       <div className="flex justify-between items-center">
-        {isEditing ? (
+        {!isDefaultFolder && isEditing ? (
           <button
             aria-label="update folder"
             type="button"

--- a/src/domains/wish/components/WishFolder/index.tsx
+++ b/src/domains/wish/components/WishFolder/index.tsx
@@ -39,7 +39,7 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
     openPopup(<DeleteWishFolderPopup folderName={name} folderId={id} />);
   };
 
-  const updateFolderName: MouseEventHandler<HTMLButtonElement> = () => {
+  const updateFolderName = () => {
     if (isDefaultFolder) {
       openPopup(<DefaultFolderAlertPopup />);
       return;
@@ -58,8 +58,9 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
   return (
     <div className="flex flex-col gap-[6.5px] rounded-[6px] overflow-hidden">
       <Link
-        href={`${PATH.wishProductList}/${id}`}
+        href={`${PATH.wishProductList}/${isEditing ? '' : id}`}
         className="relative flex justify-center items-center after:pb-[100%] w-full"
+        onClick={() => isEditing && updateFolderName()}
       >
         <FolderThumbnail thumbnailList={thumbnailList} />
 

--- a/src/domains/wish/components/WishFolder/index.tsx
+++ b/src/domains/wish/components/WishFolder/index.tsx
@@ -26,7 +26,7 @@ const DEFAULT_FOLDER_NAME = '기본 폴더';
 const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
   const isEditing = useRecoilValue(isWishFolderEditingState);
   const { openPopup } = usePopup();
-  const { openModal } = useModal();
+  const { openModal, closeModal } = useModal();
   const { mutate: updateWishFolderTitle } = useUpdateWishFolderMutation();
   const isDefaultFolder = useMemo(() => DEFAULT_FOLDER_NAME === name, [name]);
 
@@ -49,7 +49,7 @@ const WishFolder = ({ id, thumbnailList, name, count }: WishFolderProps) => {
     openModal(
       <UpdateWishFolderModal
         onValidSubmit={({ title }) => {
-          updateWishFolderTitle({ title, folderId: id });
+          updateWishFolderTitle({ title, folderId: id }, { onSuccess: closeModal });
         }}
       />
     );

--- a/src/domains/wish/components/alert-box/DefaultFolderAlertPopup.tsx
+++ b/src/domains/wish/components/alert-box/DefaultFolderAlertPopup.tsx
@@ -9,7 +9,7 @@ const DefaultFolderAlertPopup = () => {
   return (
     <Popup>
       <PaddingWrapper className="text-center mt-[16px]">
-        기본 폴더는 삭제하실 수 없습니다.
+        기본 폴더는 수정 및 삭제하실 수 없습니다.
       </PaddingWrapper>
       <PaddingWrapper>
         <Button onClick={closePopup}>확인</Button>

--- a/src/domains/wish/components/alert-box/DefaultFolderAlertPopup.tsx
+++ b/src/domains/wish/components/alert-box/DefaultFolderAlertPopup.tsx
@@ -1,0 +1,21 @@
+import Button from '@/shared/components/Button';
+import PaddingWrapper from '@/shared/components/PaddingWrapper';
+import Popup from '@/shared/components/Popup';
+import usePopup from '@/shared/hooks/usePopup';
+
+const DefaultFolderAlertPopup = () => {
+  const { closePopup } = usePopup();
+
+  return (
+    <Popup>
+      <PaddingWrapper className="text-center mt-[16px]">
+        기본 폴더는 삭제하실 수 없습니다.
+      </PaddingWrapper>
+      <PaddingWrapper>
+        <Button onClick={closePopup}>확인</Button>
+      </PaddingWrapper>
+    </Popup>
+  );
+};
+
+export default DefaultFolderAlertPopup;

--- a/src/domains/wish/components/alert-box/DeleteWishFolderPopup.tsx
+++ b/src/domains/wish/components/alert-box/DeleteWishFolderPopup.tsx
@@ -36,7 +36,7 @@ const DeleteWishFolderPopup = ({ folderName, folderId }: DeleteWishFolderPopupPr
           취소
         </Button>
         <Button onClick={deleteWishFolder} variants="primary-black">
-          확인
+          삭제
         </Button>
       </PaddingWrapper>
     </Popup>

--- a/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
+++ b/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
@@ -38,7 +38,6 @@ const UpdateWishFolderModal = ({ onValidSubmit, prevTitle }: Props) => {
               <span className="text-gray-400">/{MAX_LENGTH}</span>
             </div>
           </div>
-          {/* TODO 색상 코드 확인 후 disable에 대한 bg 컬러 변경 */}
           <ButtonNewver type="submit" disabled={isDisable} className="bg-black">
             확인
           </ButtonNewver>

--- a/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
+++ b/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
@@ -37,6 +37,7 @@ const UpdateWishFolderModal = ({ onValidSubmit, prevTitle }: Props) => {
               <span className="text-gray-400">/{MAX_LENGTH}</span>
             </div>
           </div>
+          {/* TODO 색상 코드 확인 후 disable에 대한 bg 컬러 변경 */}
           <Button type="submit" disabled={isDisable} className={isDisable ? 'bg-gray-600' : ''}>
             확인
           </Button>

--- a/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
+++ b/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
@@ -6,7 +6,10 @@ import PaddingWrapper from '@/shared/components/PaddingWrapper';
 import Input from '@/shared/components/Input';
 import Modal from '@/shared/components/Modal';
 import ButtonNewver from '@/shared/components/ButtonNewver';
+import usePopup from '@/shared/hooks/usePopup';
 import { CreateWishFolderReqeust } from '../../types/form';
+import { DEFAULT_FOLDER_NAME } from '../../constants';
+import DefaultFolderAlertPopup from './DefaultFolderAlertPopup';
 
 interface Props {
   onValidSubmit: SubmitHandler<CreateWishFolderReqeust>;
@@ -19,12 +22,25 @@ const UpdateWishFolderModal = ({ onValidSubmit, prevTitle }: Props) => {
   const { register, handleSubmit, watch } = useForm<CreateWishFolderReqeust>({
     defaultValues: { title: prevTitle ?? '' }
   });
-  const isDisable = prevTitle === watch('title');
+
+  /* TODO
+  "기본 폴더"에 대한 임시 방편 - 백엔드와의 논의 후 결정 */
+  const { openPopup } = usePopup();
+  const onSubmit: SubmitHandler<CreateWishFolderReqeust> = (data) => {
+    if (data.title === DEFAULT_FOLDER_NAME) {
+      openPopup(<DefaultFolderAlertPopup />);
+      return;
+    }
+
+    onValidSubmit(data);
+  };
+
+  const isDisable = prevTitle === watch('title') || DEFAULT_FOLDER_NAME === watch('title');
 
   return (
     <Modal title="찜 폴더">
       <PaddingWrapper>
-        <form onSubmit={handleSubmit(onValidSubmit)} className="flex flex-col gap-[16px]">
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-[16px]">
           <div className="flex flex-col items-end gap-[4px]">
             <Input
               {...register('title', { required: true })}

--- a/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
+++ b/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
@@ -6,17 +6,17 @@ import Button from '@/shared/components/Button';
 import Input from '@/shared/components/Input';
 import Modal from '@/shared/components/Modal';
 import { CreateWishFolderReqeust } from '../../types/form';
-import { NEW_WISH_FOLDER_KEY } from '../../constants';
 
 interface Props {
   onValidSubmit: SubmitHandler<CreateWishFolderReqeust>;
-  prevTitle: string;
+  prevTitle?: string;
 }
 
 const UpdateWishFolderModal = ({ onValidSubmit, prevTitle }: Props) => {
   const MAX_LENGTH = 12;
+
   const { register, handleSubmit, watch } = useForm<CreateWishFolderReqeust>({
-    defaultValues: { title: NEW_WISH_FOLDER_KEY === prevTitle ? '' : prevTitle }
+    defaultValues: { title: prevTitle ?? '' }
   });
   const isDisable = prevTitle === watch('title');
 
@@ -38,7 +38,7 @@ const UpdateWishFolderModal = ({ onValidSubmit, prevTitle }: Props) => {
             </div>
           </div>
           {/* TODO 색상 코드 확인 후 disable에 대한 bg 컬러 변경 */}
-          <Button type="submit" disabled={isDisable} className={isDisable ? 'bg-gray-600' : ''}>
+          <Button type="submit" disabled={isDisable} className={isDisable ? 'bg-gray-300' : ''}>
             확인
           </Button>
         </form>

--- a/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
+++ b/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
@@ -6,18 +6,19 @@ import Button from '@/shared/components/Button';
 import Input from '@/shared/components/Input';
 import Modal from '@/shared/components/Modal';
 import { CreateWishFolderReqeust } from '../../types/form';
+import { NEW_WISH_FOLDER_KEY } from '../../constants';
 
 interface Props {
   onValidSubmit: SubmitHandler<CreateWishFolderReqeust>;
+  prevTitle: string;
 }
 
-const UpdateWishFolderModal = ({ onValidSubmit }: Props) => {
+const UpdateWishFolderModal = ({ onValidSubmit, prevTitle }: Props) => {
   const MAX_LENGTH = 12;
   const { register, handleSubmit, watch } = useForm<CreateWishFolderReqeust>({
-    defaultValues: { title: '' }
+    defaultValues: { title: NEW_WISH_FOLDER_KEY === prevTitle ? '' : prevTitle }
   });
-  const titleRegister = register('title', { required: true });
-  const titleLength = watch('title').length;
+  const isDisable = prevTitle === watch('title');
 
   return (
     <Modal title="찜 폴더">
@@ -25,18 +26,20 @@ const UpdateWishFolderModal = ({ onValidSubmit }: Props) => {
         <form onSubmit={handleSubmit(onValidSubmit)} className="flex flex-col gap-[16px]">
           <div className="flex flex-col items-end gap-[4px]">
             <Input
-              {...titleRegister}
+              {...register('title', { required: true })}
               type="text"
               autoComplete="off"
               maxLength={MAX_LENGTH}
               placeholder="폴더 명을 입력해주세요."
             />
             <div>
-              {titleLength}
+              {watch('title').length}
               <span className="text-gray-400">/{MAX_LENGTH}</span>
             </div>
           </div>
-          <Button type="submit">확인</Button>
+          <Button type="submit" disabled={isDisable} className={isDisable ? 'bg-gray-600' : ''}>
+            확인
+          </Button>
         </form>
       </PaddingWrapper>
     </Modal>

--- a/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
+++ b/src/domains/wish/components/alert-box/UpdateWishFolderModal.tsx
@@ -2,9 +2,10 @@
 
 import { SubmitHandler, useForm } from 'react-hook-form';
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
-import Button from '@/shared/components/Button';
+
 import Input from '@/shared/components/Input';
 import Modal from '@/shared/components/Modal';
+import ButtonNewver from '@/shared/components/ButtonNewver';
 import { CreateWishFolderReqeust } from '../../types/form';
 
 interface Props {
@@ -38,9 +39,9 @@ const UpdateWishFolderModal = ({ onValidSubmit, prevTitle }: Props) => {
             </div>
           </div>
           {/* TODO 색상 코드 확인 후 disable에 대한 bg 컬러 변경 */}
-          <Button type="submit" disabled={isDisable} className={isDisable ? 'bg-gray-300' : ''}>
+          <ButtonNewver type="submit" disabled={isDisable} className="bg-black">
             확인
-          </Button>
+          </ButtonNewver>
         </form>
       </PaddingWrapper>
     </Modal>

--- a/src/domains/wish/components/alert-box/WishFolderSelectModal.tsx
+++ b/src/domains/wish/components/alert-box/WishFolderSelectModal.tsx
@@ -14,6 +14,7 @@ import { selectedWishFolderState } from '../../atoms/wishFolder';
 import useMoveWishProduct from '../../queries/useMoveWishProduct';
 import UpdateWishFolderModal from './UpdateWishFolderModal';
 import useCreateWishFolderMutation from '../../queries/useCreateWishFolderMutation';
+import { NEW_WISH_FOLDER_KEY } from '../../constants';
 
 interface Props {
   productId: number;
@@ -34,6 +35,7 @@ const WishFolderSelectModal = ({ productId }: Props) => {
   const openCreateWishFolderModal = () => {
     openModal(
       <UpdateWishFolderModal
+        prevTitle={NEW_WISH_FOLDER_KEY}
         onValidSubmit={({ title }) => {
           createWishFolder(title);
           closeModal();

--- a/src/domains/wish/components/alert-box/WishFolderSelectModal.tsx
+++ b/src/domains/wish/components/alert-box/WishFolderSelectModal.tsx
@@ -14,7 +14,6 @@ import { selectedWishFolderState } from '../../atoms/wishFolder';
 import useMoveWishProduct from '../../queries/useMoveWishProduct';
 import UpdateWishFolderModal from './UpdateWishFolderModal';
 import useCreateWishFolderMutation from '../../queries/useCreateWishFolderMutation';
-import { NEW_WISH_FOLDER_KEY } from '../../constants';
 
 interface Props {
   productId: number;
@@ -35,7 +34,6 @@ const WishFolderSelectModal = ({ productId }: Props) => {
   const openCreateWishFolderModal = () => {
     openModal(
       <UpdateWishFolderModal
-        prevTitle={NEW_WISH_FOLDER_KEY}
         onValidSubmit={({ title }) => {
           createWishFolder(title);
           closeModal();

--- a/src/domains/wish/constants/index.ts
+++ b/src/domains/wish/constants/index.ts
@@ -9,3 +9,6 @@ export const wishSortDictionary = new Dictionary({
   인기순: 'POPULAR',
   담은순: 'WISHLIST_RECENT'
 });
+
+export const NEW_WISH_FOLDER_KEY = 'CREATE_NEW_WISH';
+export const DEFAULT_FOLDER_NAME = '기본 폴더';

--- a/src/domains/wish/constants/index.ts
+++ b/src/domains/wish/constants/index.ts
@@ -10,5 +10,6 @@ export const wishSortDictionary = new Dictionary({
   담은순: 'WISHLIST_RECENT'
 });
 
-export const NEW_WISH_FOLDER_KEY = 'CREATE_NEW_WISH';
+/* TODO
+  확실한 기본 Key 값 추가 고려 */
 export const DEFAULT_FOLDER_NAME = '기본 폴더';


### PR DESCRIPTION
## 이슈 번호

- #524 
- close #524 

Notion ( Full Test Case )

[239. 찜(상품). 찜 페이지](https://www.notion.so/sideproject-unione/239-3678e3051f0d4385a7134b720100515d?pvs=4)
[243. 찜(상품). 찜 폴더 편집](https://www.notion.so/sideproject-unione/243-aa8b9534d2cd4dd6907698b264a4751d?pvs=4)
[243. 찜(상품). 찜 폴더 편집](https://www.notion.so/sideproject-unione/243-91300456f06247c5a3df70073de25146?pvs=4)
[243. 찜(상품). 찜 폴더 편집](https://www.notion.so/sideproject-unione/243-34ce356f7a634ed09d8a497a2541cbaa?pvs=4)
[243. 찜(상품). 찜 폴더 편집 ( ❗ 추가 개선 필요 )](https://www.notion.so/sideproject-unione/243-de6c18b9ee994156bc8215b664308e64?pvs=4)


## 작업 내용 및 테스트 방법

- **Default Folder에 대해 편집 모드시 삭제 및 수정 메서드가 동작 할 수 없도록 방어 코드 적용**
```tsx
// 해당 키워드를 통해 기본 폴더 검증
export const DEFAULT_FOLDER_NAME = '기본 폴더';

// 현재의 폴더 명과 비교
const isDefaultFolder = useMemo(() => DEFAULT_FOLDER_NAME === name, [name]);
```

추가 적인 문제 사항으로 백엔드와 논의하여 계정 내부의 default folder에 대한 별도의 데이터 key값이 존재 해야 할 것 같습니다.
현재로는 default folder에 대한 제어를 다양한 곳 ( `update 모달`, `delete 모달` ) 에서 처리 해야함으로 오류 발생 확률이 높아 보입니다.

<br/>
<br/>

- **추가적인 Default Folder 방어**

`DefaultFolderAlertPopup` 을 별도로 제작하여 API 동작 혹은 모달 동작 이전에 Default Folder에 대한 수정 , 삭제를 추가적으로 방어하였습니다.

<br/>
<br/>

- **폴더 명 수정 완료 후 updateModal close 처리**
```tsx
 updateWishFolderTitle({ title, folderId: id }, { onSuccess: closeModal })
```

<br/>
<br/>

- **SingleFolder ( 계정 내부 기본 폴더만 존재하는 경우 ) 에 대한  버튼 제어**
```tsx
const isSingleFolder = useMemo(() => !wishList || wishList.length === 1, [wishList]);
```
해당 값을 통해 편집, 완료 버튼에 대한 표시를 제어하였습니다.

<br/>
<br/>

- **폴더 업데이트 모달 인풋 및 버튼 개선**
```tsx
// wishUpdateModal
interface Props {
  onValidSubmit: SubmitHandler<CreateWishFolderReqeust>;
  prevTitle: string;
}

// react-hook-form
 const { register, handleSubmit, watch } = useForm<CreateWishFolderReqeust>({
    defaultValues: { title: NEW_WISH_FOLDER_KEY === prevTitle ? '' : prevTitle }
  });
```
prevTitle Prop을 통해 새롭게 생성될 계정인지 혹은 업데이트인지에 대한 로직을 추가하였습니다.
추가로 react-hook-form의 기본값을 prevTitle을 통해 전달 받을 수 있도록 개선하였습니다.

<br/>
<br/>

- **폴더 삭제 모달 버튼 텍스트 변경 - 확인 => 삭제**

<br/>
<br/>

- **편집 모드 중 썸네일 클릭 개선**
```tsx
      <Link
        href={`${PATH.wishProductList}/${isEditing ? '' : id}`}
        className="relative flex justify-center items-center after:pb-[100%] w-full"
        onClick={() => isEditing && updateFolderName()}
      >
```
찜 폴더 편집 모드 진입 시 Link태그의 href가 동작하지 않도록 변경 및 updateFolderName Modal이 동작하게 변경

<br/>

