### PR TITLE
🐛 Fix : 찜 > API 성공 멘트 & 삭제 후 리스트 리패칭

### DIFF
--- a/src/domains/wish/components/common/FolderThumbnail.tsx
+++ b/src/domains/wish/components/common/FolderThumbnail.tsx
@@ -2,7 +2,6 @@ import ImageWithFallback from '@/shared/components/ImageWithFallback';
 import SadBbangleBox from '@/shared/components/SadBbangleBox';
 import { BbangleIcon } from '@/shared/components/icons';
 import { BLUR_DATA_URL } from '@/shared/constants/blurDataUrl';
-import Image from 'next/image';
 import { twMerge } from 'tailwind-merge';
 
 interface Props {
@@ -46,7 +45,19 @@ const FolderThumbnail = ({ thumbnailList, size = 'lg' }: Props) => {
       )}
       {hasThumbnail && thumbnailCount === 1 && (
         <div key={thumbnailList[0]} className="relative size-full">
-          <Image src={thumbnailList[0]} fill alt="thumbnail" />
+          <ImageWithFallback
+            src={thumbnailList[0]}
+            alt="상품사진"
+            placeholder="blur"
+            blurDataURL={BLUR_DATA_URL}
+            className="object-cover rounded-[6px]"
+            fill
+            fallback={
+              <SadBbangleBox className="border bg-gray-50 rounded-[6px] size-full typo-body-12-regular">
+                no image
+              </SadBbangleBox>
+            }
+          />
         </div>
       )}
       {!hasThumbnail && <BbangleIcon shape="smile" className="size-[80px]" />}

--- a/src/domains/wish/queries/useAddWishStoreMutation.ts
+++ b/src/domains/wish/queries/useAddWishStoreMutation.ts
@@ -33,7 +33,7 @@ const useAddWishStoreMutation = (storeId: number) => {
   };
 
   const onSuccess = () => {
-    openToast({ message: '💖 찜한 상품에 추가했어요' });
+    openToast({ message: '💖 찜한 스토어 리스트에 추가했어요.' });
   };
 
   const onError = ({ message }: Error) => {

--- a/src/domains/wish/queries/useDeleteWishProductMutation.ts
+++ b/src/domains/wish/queries/useDeleteWishProductMutation.ts
@@ -51,6 +51,7 @@ const useDeleteWishProductMutation = () => {
   const onSuccess = ({ productId }: { productId: number }) => {
     queryClient.invalidateQueries({ queryKey: wishQueryKey.folders() });
     queryClient.invalidateQueries({ queryKey: productQueryKey.detail(productId) });
+    queryClient.invalidateQueries({ queryKey: productQueryKey.lists() });
     openToast({ message: '💖 찜한 상품에서 삭제했어요' });
   };
 

--- a/src/domains/wish/queries/useDeleteWishStoreMutation.ts
+++ b/src/domains/wish/queries/useDeleteWishStoreMutation.ts
@@ -34,6 +34,7 @@ const useDeleteWishStoreMutation = (storeId: number) => {
   };
 
   const onSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: storeQueryKey.lists() });
     openToast({ message: '💖 찜한 스토어에서 삭제했어요' });
   };
 


### PR DESCRIPTION
## 이슈 번호

- #533 
- close #533 

## 작업 내용 및 테스트 방법

- [246. 찜(상품). 재 찜](https://www.notion.so/sideproject-unione/246-83d0b63aba48452c83abff14bca5a05c?pvs=4)
- [255. 찜(스토어). 재 찜](https://www.notion.so/sideproject-unione/255-b41dd1f6e5094e928369013b873e6a3d?pvs=4)
`invalidateQueries `를 통해 삭제 API 정상 응답 시 스토어, 상품 목록이 갱신 될 수 있도록 수정

- [255. 찜(스토어). 재 찜](https://www.notion.so/sideproject-unione/255-b83bd4c47d024588847917f9980d58e6?pvs=4)
단순 한 API 성공 시 멘트 수정

- 기존 폴더의 썸네일 이미지 태그 => `ImageWithFallback `컴포넌트로 대체 

## To reviewers
