### PR TITLE
🐛 Fix : 찜 > 동적 메세지 제공

### DIFF
--- a/src/app/main/products/[productId]/info/_blocks/SimpleInfoWithStoreSection/DetailStoreInfo/index.tsx
+++ b/src/app/main/products/[productId]/info/_blocks/SimpleInfoWithStoreSection/DetailStoreInfo/index.tsx
@@ -22,7 +22,10 @@ interface Props {
 const DetailStoreInfo = ({ storeId }: Props) => {
   const { data: storeData } = useGetStoreInfoQuery({ storeId });
   const { mutate: addMutate } = useAddWishStoreMutation(storeId);
-  const { mutate: deleteMutate } = useDeleteWishStoreMutation(storeId);
+  const { mutate: deleteMutate } = useDeleteWishStoreMutation({
+    storeId,
+    storeName: storeData ? storeData.storeName : ''
+  });
 
   const isLoggedIn = useRecoilValue(isLoggedinState);
   const { openToast } = useToastNewVer();

--- a/src/blocks/main/(detail)/products/[productId]/info/SimpleInfoWithStoreSection/DetailStoreInfo.tsx
+++ b/src/blocks/main/(detail)/products/[productId]/info/SimpleInfoWithStoreSection/DetailStoreInfo.tsx
@@ -21,7 +21,10 @@ interface Props {
 const DetailStoreInfo = ({ storeId }: Props) => {
   const { data: storeData } = useGetStoreInfoQuery({ storeId });
   const { mutate: addMutate } = useAddWishStoreMutation(storeId);
-  const { mutate: deleteMutate } = useDeleteWishStoreMutation(storeId);
+  const { mutate: deleteMutate } = useDeleteWishStoreMutation({
+    storeId,
+    storeName: storeData ? storeData.storeName : ''
+  });
   const isLoggedIn = useRecoilValue(isLoggedinState);
   const { openToast } = useToastNewVer();
 

--- a/src/domains/store/components/StoreCard.tsx
+++ b/src/domains/store/components/StoreCard.tsx
@@ -21,7 +21,7 @@ interface WishStroeProps {
 const StoreCard = ({ id, imgSrc, title, desc, isWished }: WishStroeProps) => {
   const [isWishedLocal, setIsWishedLocal] = useState(isWished);
   const { mutate: addMutate } = useAddWishStoreMutation(id);
-  const { mutate: deleteMutate } = useDeleteWishStoreMutation(id);
+  const { mutate: deleteMutate } = useDeleteWishStoreMutation({ storeId: id, storeName: title });
 
   const like = () => {
     setIsWishedLocal(true);

--- a/src/domains/wish/queries/useDeleteWishStoreMutation.ts
+++ b/src/domains/wish/queries/useDeleteWishStoreMutation.ts
@@ -6,7 +6,13 @@ import { IStoreType } from '@/domains/store/types/store';
 import { updateInfiniteQueryCache } from '../../../shared/utils/queryCache';
 import wishService from './service';
 
-const useDeleteWishStoreMutation = (storeId: number) => {
+const useDeleteWishStoreMutation = ({
+  storeId,
+  storeName
+}: {
+  storeId: number;
+  storeName: string;
+}) => {
   const { openToast } = useToastNewVer();
   const queryClient = useQueryClient();
 
@@ -35,7 +41,7 @@ const useDeleteWishStoreMutation = (storeId: number) => {
 
   const onSuccess = () => {
     queryClient.invalidateQueries({ queryKey: storeQueryKey.lists() });
-    openToast({ message: '💖 찜한 스토어에서 삭제했어요' });
+    openToast({ message: `💖 ${storeName}을 찜한 스토어에서 삭제했어요.` });
   };
 
   const onError = ({ message }: Error) => {


### PR DESCRIPTION
## 이슈 번호

- #535 
- close #535 

## 작업 내용 및 테스트 방법

- [254. 찜(스토어). 찜 해제](https://www.notion.so/sideproject-unione/254-81076e8c5e5647b288e87d920caba7cc?pvs=4)
폴더 찜 해제 시 동적인 메세지 제공

- [247. 찜(상품). 재 찜](https://www.notion.so/sideproject-unione/247-251f80177fb848958270212c85bac0f9?pvs=4)
해당 테스트 케이스의 경우
  -  제품에 대해 찜 해제시 제품이 리스트에서 바로 사라지도록 변경되어졌기 때문에 적용 불필요

## To reviewers
