### PR TITLE
🐛 Fix :  사진 다수 선택 불가

### DIFF
--- a/src/domains/review/components/ReviewWriteForm/CommentSection/ImageUploadSection/index.tsx
+++ b/src/domains/review/components/ReviewWriteForm/CommentSection/ImageUploadSection/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, useEffect } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { CameraIcon } from '@/shared/components/icons';
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
 import ImageInput from '@/shared/components/ImageInput';
@@ -11,6 +11,7 @@ import useImageUploadMutation from '@/domains/review/queries/useImageUploadMutat
 import PreviewImage from './PreviewImage';
 
 const ImageUploadSection = () => {
+  const [saveImage, setSaveImage] = useState<File[]>([]);
   const { mutate: imageUploadMutate, data: images, isSuccess } = useImageUploadMutation(['review']);
   const { register, setValue, watch, getValues } = useFormContext<IReviewWriteForm>();
   const { openToast } = useToastNewVer();
@@ -25,24 +26,24 @@ const ImageUploadSection = () => {
     const { files } = e.target;
 
     if (!files || files.length === 0) return;
-    if (files.length > 5) {
+    if (files.length + saveImage.length > 5) {
       openToast({ message: '최대 5개까지 업로드할 수 있습니다' });
       return;
     }
-    imageUploadMutate(files);
+
+    const newList = [...saveImage, ...Array.from(files)];
+
+    setSaveImage(newList);
+    imageUploadMutate(newList);
   };
 
   const handleImageRemove = (idxToRemove: number) => {
-    const dataTransfer = new DataTransfer();
     const files = getValues('images.files');
     const urls = getValues('images.urls');
     const filteredFiles = files && Array.from(files).filter((_, idx) => idx !== idxToRemove);
     const filteredUrls = urls?.filter((_, idx) => idx !== idxToRemove);
 
-    filteredFiles?.forEach((file) => {
-      dataTransfer.items.add(file);
-    });
-    setValue('images.files', dataTransfer.files);
+    setValue('images.files', filteredFiles);
     setValue('images.urls', filteredUrls);
   };
 

--- a/src/domains/review/components/ReviewWriteForm/CommentSection/ImageUploadSection/index.tsx
+++ b/src/domains/review/components/ReviewWriteForm/CommentSection/ImageUploadSection/index.tsx
@@ -11,7 +11,7 @@ import useImageUploadMutation from '@/domains/review/queries/useImageUploadMutat
 import PreviewImage from './PreviewImage';
 
 const ImageUploadSection = () => {
-  const { mutate: imageUploadMuate, data: images, isSuccess } = useImageUploadMutation(['review']);
+  const { mutate: imageUploadMutate, data: images, isSuccess } = useImageUploadMutation(['review']);
   const { register, setValue, watch, getValues } = useFormContext<IReviewWriteForm>();
   const { openToast } = useToastNewVer();
 
@@ -23,12 +23,13 @@ const ImageUploadSection = () => {
 
   const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
+
     if (!files || files.length === 0) return;
     if (files.length > 5) {
       openToast({ message: '최대 5개까지 업로드할 수 있습니다' });
       return;
     }
-    imageUploadMuate(files);
+    imageUploadMutate(files);
   };
 
   const handleImageRemove = (idxToRemove: number) => {

--- a/src/domains/review/queries/service.ts
+++ b/src/domains/review/queries/service.ts
@@ -67,10 +67,10 @@ class ReviewService extends Service {
     if (!res.ok || !success) throw new Error(ERROR_MESSAGE.api({ code, message }));
   }
 
-  async uploadImage(images: FileList) {
+  async uploadImage(images: File[]) {
     const formData = new FormData();
 
-    Array.from(images).forEach((image) => {
+    images.forEach((image) => {
       formData.append('images', image);
     });
     formData.append('category', 'REVIEW');

--- a/src/domains/review/queries/useImageUploadMutation.ts
+++ b/src/domains/review/queries/useImageUploadMutation.ts
@@ -7,7 +7,7 @@ const useImageUploadMutation = (key: MutationKey) => {
 
   return useMutation({
     mutationKey: key,
-    mutationFn: (images: FileList) => reviewService.uploadImage(images),
+    mutationFn: (images: File[]) => reviewService.uploadImage(images),
     onError: (error) => {
       openToast({ message: error.message });
     }

--- a/src/domains/review/types/review.ts
+++ b/src/domains/review/types/review.ts
@@ -44,7 +44,7 @@ export interface IReviewWriteForm {
   content: string;
   boardId: number;
   images: {
-    files?: FileList;
+    files?: File[];
     urls?: string[];
   };
 }


### PR DESCRIPTION
## 이슈 번호

> - #549

close #439  

## 작업 내용 및 테스트 방법

이미지 업로드 과정에서 기존에 이미 업로드 되어있는 이미지를 유지하지 않고
새로운 이미지가 업로드 되는 과정에서 기존 이미지들을 덮어 씌워버리는 문제

따라서 기존 3개의 이미지가 존재한 상황에서 새로운 이미지 2개를 업로드 할 경우!
3 + 2 로 5개의 업로드가 이미지가 되는 방법이 아닌 기존 3개의 이미지가 지워지고 2개의 이미지만 남게 되는 상황

- 해당 문제를 개선하기 위해 기존 `FileList` 타입으로 다뤄 지던 이미지 데이터를 `File[]` 형태로 변경
  -  `FileList` 의 경우 유사 배열 형식 이기 때문에 가공 할 수 없음

- 이후 saveImage 라는 상태로 이전 이미지들을 저장할 수 있도록 구현
  - Form 내부에 저장되어있는 Image를 바로 사용할 수 있다면 좋겠지만, 현재 Input의 구조 상 유저가 이미지 등록을 마치는 onChnage가 발동되게 되고 **기존 저장되어진 이미지에 접근할 수 없음**. 

```tsx
  const [saveImage, setSaveImage] = useState<File[]>([]);

  // ....

  const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
    const { files } = e.target;

    if (!files || files.length === 0) return;
    if (files.length + saveImage.length > 5) {
      openToast({ message: '최대 5개까지 업로드할 수 있습니다' });
      return;
    }

    const newList = [...saveImage, ...Array.from(files)];

    setSaveImage(newList);
    imageUploadMutate(newList);
  };
  
```

## To reviewers
