### PR TITLE
🐛 Fix : 상품 검색시 UI에 반영되는 상품의 totalCount 수정

### DIFF
--- a/src/domains/search/queries/service.ts
+++ b/src/domains/search/queries/service.ts
@@ -72,7 +72,7 @@ class SearchService extends Service {
     const content: IProductType[] = Array.isArray(result.content) ? result.content : [];
 
     return {
-      totalCount: content.length,
+      totalCount: result.totalCount,
       nextCursor: result.nextCursor,
       hasNext: result.hasNext,
       content

--- a/src/shared/types/response.ts
+++ b/src/shared/types/response.ts
@@ -23,6 +23,7 @@ export interface ResultResponse<T> extends DefaultResponse {
 export interface Cursor<T> {
   nextCursor: number;
   hasNext: boolean;
+  totalCount: number;
   content: T;
 }
 


### PR DESCRIPTION
## 이슈 번호

> #604   

## 작업 내용 및 테스트 방법
- 기존 `getSearchProducts` 에서는 content의 length를 return하고 있었는데요, prefetch로 인해 한페이지(30개)의 상품만 length에 count 되었기 때문에 30개가 초과되는 제품을 검색할 경우 어떠한 초과값이 산정되더라도 30이라는 length를 return 한것 같습니다.
- content -> result.totalCount로 수정하여 전체 상품의 length를 return 하도록 수정하였습니다.
<img width="972" alt="검색 결과 총개수 수정" src="https://github.com/user-attachments/assets/011107e7-d39c-4679-b037-1b0905a49560" />
