### PR TITLE
🐛 Fix :  새로고침시 API 호출 안되는 이슈 해결

### DIFF
--- a/src/app/(with-navigation)/search/(intro)/@popularKeyword/error.tsx
+++ b/src/app/(with-navigation)/search/(intro)/@popularKeyword/error.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
+import { startTransition, useEffect } from 'react';
 import Button from '@/shared/components/Button';
 import { RefreshIcon } from '@/shared/components/icons';
+import { useRouter } from 'next/navigation';
 
 const PopularKeywordError = ({
   error,
@@ -11,16 +12,25 @@ const PopularKeywordError = ({
   error: Error & { digest?: string };
   reset: () => void;
 }) => {
+  const router = useRouter();
+
   useEffect(() => {
     console.error(error);
   }, [error]);
+
+  const handleReset = () => {
+    startTransition(() => {
+      router.refresh();
+      reset();
+    });
+  };
 
   return (
     <div className="flex flex-col items-center typo-title-14-regular text-gray-500">
       <p>네트워크 문제로 일시적인 오류가 발생했어요.</p>
       <p>다시 시도해주세요.</p>
       <Button
-        onClick={reset}
+        onClick={handleReset}
         variants="primary-white"
         className="flex gap-x-[2px] justify-center items-center mt-[16px] p-[16px] w-[149px] typo-title-16-medium"
       >

--- a/src/app/(with-navigation)/search/(searchResult)/products/page.tsx
+++ b/src/app/(with-navigation)/search/(searchResult)/products/page.tsx
@@ -1,14 +1,15 @@
-'use client';
-
 import SortingFilterSection from '@/blocks/main/(list)/SortingFilterSection';
 import SearchProductList from '@/blocks/search/products/SearchProductList';
 import { FILTER_FAMILY_ID } from '@/domains/product/constants/filterFamilyID';
 import TopButton from '@/shared/components/TopButton';
-import { useSearchParams } from 'next/navigation';
 
-const SearchProducts = () => {
-  const params = useSearchParams();
-  const keyword = params.get('query') ?? '';
+interface SearchProductsProps {
+  searchParams: { query?: string };
+}
+
+const SearchProducts = async ({ searchParams }: SearchProductsProps) => {
+  const params = await searchParams;
+  const keyword = params.query ?? '';
 
   return (
     <>

--- a/src/app/(with-navigation)/search/(searchResult)/products/page.tsx
+++ b/src/app/(with-navigation)/search/(searchResult)/products/page.tsx
@@ -1,14 +1,14 @@
+'use client';
+
 import SortingFilterSection from '@/blocks/main/(list)/SortingFilterSection';
 import SearchProductList from '@/blocks/search/products/SearchProductList';
 import { FILTER_FAMILY_ID } from '@/domains/product/constants/filterFamilyID';
 import TopButton from '@/shared/components/TopButton';
+import { useSearchParams } from 'next/navigation';
 
-interface SearchProductsProps {
-  searchParams: { query?: string };
-}
-
-const SearchProducts = async ({ searchParams }: SearchProductsProps) => {
-  const keyword = searchParams.query ?? '';
+const SearchProducts = () => {
+  const params = useSearchParams();
+  const keyword = params.get('query') ?? '';
 
   return (
     <>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -6,13 +6,22 @@ import SadBbangleBox from '@/shared/components/SadBbangleBox';
 import { BbangleIcon } from '@/shared/components/icons';
 import PATH from '@/shared/constants/path';
 import Link from 'next/link';
-import { useEffect } from 'react';
+import { startTransition, useEffect } from 'react';
 import DefaultLayout from '@/shared/components/DefaultLayout';
+import { useRouter } from 'next/navigation';
 
 const Error = ({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) => {
+  const router = useRouter();
   useEffect(() => {
     console.error(error.digest);
   });
+
+  const handleReset = () => {
+    startTransition(() => {
+      router.refresh();
+      reset();
+    });
+  };
 
   return (
     <DefaultLayout
@@ -28,7 +37,7 @@ const Error = ({ error, reset }: { error: Error & { digest?: string }; reset: ()
           <SadBbangleBox>
             <div>일시적인 오류가 발생했어요.</div>
             <div>다시 시도해주세요.</div>
-            <ButtonNewver className="mt-[16px]" onClick={reset} color="black">
+            <ButtonNewver className="mt-[16px]" onClick={handleReset} color="black">
               다시 시도하기
             </ButtonNewver>
           </SadBbangleBox>


### PR DESCRIPTION
## 이슈 번호

> #614 

## 작업 내용 및 테스트 방법

- https://nextjs.org/docs/app/guides/upgrading/version-15#params--searchparams 참고하여 Next 15에서 다뤄지는 searchParams 구현 코드로 수정하였습니다.

- 에러핸들링(다시 시도하기)새로고침 시 API 호출이 안들어갔는데요, 원인은 다음과 같습니다.
➡️ reset() 을 호출해도 서버 컴포넌트를 리렌더링 되지 않고 클라이언트 컴포넌트만 렌더링되기 때문에

`router.refersh()` 를 사용해보았으나, reset()이 먼저 호출되는 경우도 있어 정상적으로 구현이 어려웠습니다.

react 18 부터 지원되는 `startTransition` 콜백함수를 활용해서 순차적으로 reset(), refresh() 가 되게 구현하니, 새로고침시에도 API 요청 정상적으로 들어가는 걸 확인했습니다.

https://github.com/user-attachments/assets/98804830-f1cd-4e56-8abf-cc27c2e7e844



## To reviewers
```js
  const router = useRouter();
  useEffect(() => {
    console.error(error.digest);
  });

  const handleReset = () => {
    startTransition(() => {
      router.refresh();
      reset();
    });
  };
```
- root의 error UI와, 인기 검색어 error UI 컴포넌트에 해당 핸들링 함수가 구현되어있는데요, 조금 더 효율적인 방법이 없을까 고민중입니다!
- 검색페이지의 error UI는 구버전이 맞는거 같은데, 피그마에서는 디자인 파트에서의 수정 사항이 없는 거 같아서 디자인 수정은 따로 진행하지 않았습니다.

<img width="170" alt="Screenshot 2025-06-10 at 1 47 53 PM (2)" src="https://github.com/user-attachments/assets/d9d69fea-8066-4434-99d3-9a5f5e5e1c1e" />
<img width="334" alt="Screenshot 2025-06-10 at 1 47 38 PM" src="https://github.com/user-attachments/assets/1be7b53e-ab5c-4258-9d08-9e299f080442" />

