### PR TITLE
 ✨ Feat : 로그인 시 보던 화면으로 이동 

### DIFF
--- a/src/app/main/products/[productId]/review/_blocks/ReviewCreateButton.tsx
+++ b/src/app/main/products/[productId]/review/_blocks/ReviewCreateButton.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useAtom } from 'jotai';
 import { isLoggedinAtom } from '@/shared/atoms/login';
@@ -8,6 +7,7 @@ import { ERROR_MESSAGE } from '@/shared/constants/error';
 import ButtonNewver from '@/shared/components/ButtonNewver';
 import useToastNewVer from '@/shared/hooks/useToastNewVer';
 import PATH from '@/shared/constants/path';
+import RequiredLoginToast from '@/shared/components/RequiredLoginToast';
 
 interface Props {
   productId: number;
@@ -25,11 +25,7 @@ const ReviewCreateButton = ({ productId }: Props) => {
     }
     openToast({
       message: ERROR_MESSAGE.requiredLogin,
-      action: (
-        <Link className="hover:underline" href={PATH.login}>
-          로그인
-        </Link>
-      )
+      action: <RequiredLoginToast />
     });
   };
 

--- a/src/blocks/store/StoreInfoSection.tsx
+++ b/src/blocks/store/StoreInfoSection.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import Image from 'next/image';
 import PaddingWrapper from '@/shared/components/PaddingWrapper';
 import StarButton from '@/shared/components/StarButton';
@@ -18,22 +17,16 @@ interface Props {
 
 const StoreInfoSection = ({ storeId }: Props) => {
   const { data: storeInfo } = useGetStoreInfoQuery({ storeId });
-  const [isLiked, setIsLiked] = useState(storeInfo?.isWished || false);
   const [isLoggedIn] = useAtom(isLoggedinAtom);
+  const isLiked = storeInfo?.isWished || false;
 
   const { mutate: addMutate } = useAddWishStoreMutation({
     storeId,
-    storeName: storeInfo?.storeName ?? '🏠',
-    successCallback: () => {
-      setIsLiked(true);
-    }
+    storeName: storeInfo?.storeName ?? '🏠'
   });
   const { mutate: deleteMutate } = useDeleteWishStoreMutation({
     storeId,
-    storeName: storeInfo?.storeName ?? '🏠',
-    successCallback: () => {
-      setIsLiked(false);
-    }
+    storeName: storeInfo?.storeName ?? '🏠'
   });
   const { openToast } = useToastNewVer();
 

--- a/src/domains/user/queries/useLoginMutation.ts
+++ b/src/domains/user/queries/useLoginMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import useToastNewVer from '@/shared/hooks/useToastNewVer';
 import useAuth from '@/shared/hooks/useAuth';
 import PATH from '@/shared/constants/path';
@@ -7,10 +7,12 @@ import { LoginResponse, SocialType } from '../types/login';
 import userService from './service';
 
 export function useSocialLoginMutation() {
+  const queryParams = useSearchParams();
   const { openToast } = useToastNewVer();
   const { replace } = useRouter();
   const { login } = useAuth();
 
+  const redirectTo = queryParams.get('from') ?? PATH.home;
   const mutationFn = ({
     socialToken,
     socialType
@@ -38,7 +40,7 @@ export function useSocialLoginMutation() {
     }
 
     openToast({ message: '로그인 되었어요.' });
-    replace(PATH.home);
+    replace(redirectTo);
   };
 
   const onError = () => {

--- a/src/shared/components/RequiredLoginToast.tsx
+++ b/src/shared/components/RequiredLoginToast.tsx
@@ -1,15 +1,22 @@
-import Link from 'next/link';
-import { ERROR_MESSAGE } from '../constants/error';
-import PATH from '../constants/path';
-import ToastPop from './ToastPop';
+'use client';
 
-const RequiredLoginToast = () => (
-  <ToastPop>
-    <span>{ERROR_MESSAGE.requiredLogin}</span>
-    <Link className="hover:underline" href={PATH.login}>
-      로그인
-    </Link>
-  </ToastPop>
-);
+import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
+import PATH from '../constants/path';
+
+const RequiredLoginToast = () => {
+  const redirectPath = usePathname();
+  const searchParams = useSearchParams();
+
+  const queryString = searchParams.toString();
+  const fullPath = queryString ? `${redirectPath}?${queryString}` : redirectPath;
+  const encodedPath = encodeURIComponent(fullPath);
+
+  return (
+    <Link className="hover:underline" href={`${PATH.login}?from=${encodedPath}`}>
+        로그인
+      </Link>
+  );
+};
 
 export default RequiredLoginToast;


### PR DESCRIPTION
## 이슈 번호

>  https://www.notion.so/sideproject-unione/1f6622e86d3d8037b81edaf67cd65f99?p=205622e86d3d802e94cede8faa24f48a&pm=s

## 작업 내용 및 테스트 방법

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## To reviewers

로그인시 이전 보고있던 화면의 정보를 from 쿼리에 저장하고 이를 기반으로 다시 돌아가도록 구현했습니다.

이전 작업에서 불필요한 state를 제거했습니다.