### PR TITLE
✨ Feat: 맞춤 추천 선택 개수 문제

### DIFF
--- a/src/app/mypage/recommendation/create/_blocks/ButtonSection.tsx
+++ b/src/app/mypage/recommendation/create/_blocks/ButtonSection.tsx
@@ -10,8 +10,7 @@ import { RecommendationType } from '@/domains/user/types/recommendation';
 const ButtonSection = () => {
   const { progress } = useParams<{ progress: '1' | '2' }>();
   const { watch } = useFormContext<RecommendationType>();
-  const { step1, step2 } = watch();
-  const isStep1Disabled = step1.preferenceType.length === 0;
+  const { step2 } = watch();
   const isStep2Disabled =
     !(step2.dietLimitation.length > 0) ||
     !(step2.healthConcerns.length > 0) ||
@@ -20,8 +19,7 @@ const ButtonSection = () => {
   const config = {
     '1': {
       children: '다음',
-      form: FORM_ID.recommendationCreateStep1,
-      disabled: isStep1Disabled
+      form: FORM_ID.recommendationCreateStep1
     },
     '2': {
       children: '완료',

--- a/src/app/mypage/recommendation/create/_blocks/RecommendationCreateForm.tsx
+++ b/src/app/mypage/recommendation/create/_blocks/RecommendationCreateForm.tsx
@@ -6,6 +6,7 @@ import { SubmitHandler, useFormContext } from 'react-hook-form';
 import { FORM_ID } from '@/domains/user/constants/form';
 import RecommendationStep1Form from '@/domains/user/components/RecommendationStep1Form';
 import RecommendationStep2Form from '@/domains/user/components/RecommendationStep2Form';
+import { RECOMMENDATION_PROVIDER_DEFAULT_VALUE } from '@/domains/user/constants/recommendation';
 
 interface Props {
   progress: 1 | 2;
@@ -16,7 +17,7 @@ const RecommendationCreateForm = ({ progress }: Props) => {
   const { mutateStep1, mutateStep2 } = useAddRecommendationMutation();
 
   const onStep1Valid: SubmitHandler<RecommendationType> = ({ step1 }) => {
-    mutateStep1(step1);
+    mutateStep1(step1 || RECOMMENDATION_PROVIDER_DEFAULT_VALUE.step1);
   };
 
   const onStep2Valid: SubmitHandler<RecommendationType> = ({ step2 }) => {

--- a/src/app/mypage/recommendation/update/_blocks/ButtonSection.tsx
+++ b/src/app/mypage/recommendation/update/_blocks/ButtonSection.tsx
@@ -10,8 +10,7 @@ import { RecommendationType } from '@/domains/user/types/recommendation';
 const ButtonSection = () => {
   const { progress } = useParams<{ progress: '1' | '2' }>();
   const { watch } = useFormContext<RecommendationType>();
-  const { step1, step2 } = watch();
-  const isStep1Disabled = step1.preferenceType.length === 0;
+  const { step2 } = watch();
   const isStep2Disabled =
     !(step2.dietLimitation.length > 0) ||
     !(step2.healthConcerns.length > 0) ||
@@ -20,8 +19,7 @@ const ButtonSection = () => {
   const config = {
     '1': {
       children: '다음',
-      form: FORM_ID.recommendationUpdateStep1,
-      disabled: isStep1Disabled
+      form: FORM_ID.recommendationUpdateStep1
     },
     '2': {
       children: '수정 완료',

--- a/src/blocks/home/BestProductsSection/TitleSection.tsx
+++ b/src/blocks/home/BestProductsSection/TitleSection.tsx
@@ -11,10 +11,16 @@ const TitleSection = async () => {
   const isLoggedIn = !!accessToken;
 
   let preference;
+  let nickname;
+
   if (isLoggedIn) {
     try {
-      const recommendationStep1 = await userService.getRecommendationStep1();
+      const [recommendationStep1, userProfile] = await Promise.all([
+        userService.getRecommendationStep1(),
+        userService.getUserProfile()
+      ]);
       preference = recommendationStep1.preferenceType;
+      nickname = userProfile.nickname;
     } catch (error) {
       if (error instanceof Error) console.error(error.message);
     }
@@ -42,7 +48,9 @@ const TitleSection = async () => {
       </div>
       {isLoggedIn && preference && (
         <p className="typo-body-12-regular mt-[6px] whitespace-pre-line text-gray-600">
-          {genGuidanceMessage(preference)}
+          {preference?.[0] === undefined
+            ? `${nickname}님을 위한 위한 맞춤 추천 설정을 해보세요!`
+            : genGuidanceMessage(preference)}
         </p>
       )}
     </PaddingWrapper>

--- a/src/blocks/home/BestProductsSection/TitleSection.tsx
+++ b/src/blocks/home/BestProductsSection/TitleSection.tsx
@@ -49,7 +49,7 @@ const TitleSection = async () => {
       {isLoggedIn && preference && (
         <p className="typo-body-12-regular mt-[6px] whitespace-pre-line text-gray-600">
           {preference?.[0] === undefined
-            ? `${nickname} 님을 위한 위한 맞춤 추천 설정을 해보세요!`
+            ? `${nickname}님을 위한 위한 맞춤 추천 설정을 해보세요!`
             : genGuidanceMessage(preference)}
         </p>
       )}

--- a/src/blocks/home/BestProductsSection/TitleSection.tsx
+++ b/src/blocks/home/BestProductsSection/TitleSection.tsx
@@ -49,7 +49,7 @@ const TitleSection = async () => {
       {isLoggedIn && preference && (
         <p className="typo-body-12-regular mt-[6px] whitespace-pre-line text-gray-600">
           {preference?.[0] === undefined
-            ? `${nickname}님을 위한 위한 맞춤 추천 설정을 해보세요!`
+            ? `${nickname} 님을 위한 위한 맞춤 추천 설정을 해보세요!`
             : genGuidanceMessage(preference)}
         </p>
       )}

--- a/src/domains/user/components/RecommendationStep1Form/CheckSection.tsx
+++ b/src/domains/user/components/RecommendationStep1Form/CheckSection.tsx
@@ -53,7 +53,7 @@ const CheckSection = () => {
               checked={checked}
               disabled={disabled}
               {...register('step1.preferenceType', {
-                required: true
+                required: false
               })}
             />
             <div className="flex flex-col">

--- a/src/domains/user/utils/recommendation.ts
+++ b/src/domains/user/utils/recommendation.ts
@@ -39,8 +39,12 @@ export const recommendationDictionary = new Dictionary({
   해당없음: 'NOT_APPLICABLE'
 });
 
-export const processKrArrayToEngString = (preferenceType: Array<PreferenceType>): string =>
-  preferenceType.map((ele) => recommendationDictionary.translate(ele)).join('_');
+export const processKrArrayToEngString = (preferenceType: Array<PreferenceType>): string => {
+  if (preferenceType.length === 0) {
+    return 'NONE';
+  }
+  return preferenceType.map((ele) => recommendationDictionary.translate(ele)).join('_');
+};
 
 export const processEngStringToKrArray = (preferenceType: string): Array<PreferenceType> =>
   preferenceType

--- a/src/shared/utils/attachPostPosition.ts
+++ b/src/shared/utils/attachPostPosition.ts
@@ -1,7 +1,11 @@
 export const attachPostPosition = (
-  word: string,
+  word: string | undefined,
   postPosition: '은' | '는' | '이' | '가' | '을' | '를' | '과' | '와'
 ) => {
+  if (!word || typeof word !== 'string') {
+    return postPosition;
+  }
+
   const lastIdx = word.length - 1;
   const lastCharCode = word.charCodeAt(lastIdx);
 


### PR DESCRIPTION
## 이슈 번호

> #621 

## 작업 내용 및 테스트 방법

https://github.com/user-attachments/assets/1a3db8c6-9f77-4893-9b36-83ea9e794a85

- 개인 맞춤 설정을 진행하지 않아도 유저 플로우가 진행될 수 있게끔 수정하였습니다.
- 회원가입시에도 최초 선택하는 form이 있는데요, 해당 form에도 동일하게 적용하였습니다.
- 맞춤 설정하지 않은 경우에는 `{닉네임}님을 위한 맞춤 추천 설정을 해보세요!` 라는 Text가 렌더링 되게 구현하였습니다.
