### PR TITLE
✨ Feat: 외부 유입 링크 추적 라우트 추가

### DIFF
--- a/src/app/link/[channel]/route.ts
+++ b/src/app/link/[channel]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isLinkChannel } from '@/domains/linktracking/constants/linkChannel';
+import linkTrackingService from '@/domains/linktracking/queries/service';
+
+export const dynamic = 'force-dynamic';
+
+export const GET = async (
+  request: NextRequest,
+  { params }: { params: Promise<{ channel: string }> }
+) => {
+  const { channel } = await params;
+
+  if (!isLinkChannel(channel)) {
+    return new NextResponse('유효하지 않은 채널입니다.', { status: 400 });
+  }
+
+  try {
+    const destinationUrl = await linkTrackingService.recordVisit({
+      channel,
+      userAgent: request.headers.get('user-agent') ?? '',
+      referer: request.headers.get('referer') ?? '',
+      forwardedFor: request.headers.get('x-forwarded-for') ?? ''
+    });
+
+    if (!destinationUrl) {
+      return new NextResponse('추적 링크를 찾을 수 없습니다.', { status: 404 });
+    }
+
+    return NextResponse.redirect(destinationUrl, 302);
+  } catch (e) {
+    console.error('링크 추적 중 에러:', e);
+    return new NextResponse('일시적인 오류가 발생했어요.', { status: 500 });
+  }
+};

--- a/src/domains/linktracking/constants/linkChannel.ts
+++ b/src/domains/linktracking/constants/linkChannel.ts
@@ -1,0 +1,9 @@
+export const LINK_CHANNEL = {
+  INSTAGRAM: 'instagram',
+  NAVER_BLOG: 'naver_blog'
+} as const;
+
+export type LinkChannel = (typeof LINK_CHANNEL)[keyof typeof LINK_CHANNEL];
+
+export const isLinkChannel = (value: string): value is LinkChannel =>
+  Object.values(LINK_CHANNEL).includes(value as LinkChannel);

--- a/src/domains/linktracking/queries/service.ts
+++ b/src/domains/linktracking/queries/service.ts
@@ -1,0 +1,32 @@
+import { LinkChannel } from '@/domains/linktracking/constants/linkChannel';
+import Service from '@/shared/queries/service';
+
+class LinkTrackingService extends Service {
+  async recordVisit({
+    channel,
+    userAgent,
+    referer,
+    forwardedFor
+  }: {
+    channel: LinkChannel;
+    userAgent: string;
+    referer: string;
+    forwardedFor: string;
+  }) {
+    const res = await this.fetchExtend.get(`/link/${channel.toUpperCase()}`, {
+      redirect: 'manual',
+      cache: 'no-store',
+      headers: {
+        'User-Agent': userAgent,
+        Referer: referer,
+        'X-Forwarded-For': forwardedFor
+      }
+    });
+
+    return res.headers.get('location');
+  }
+}
+
+const linkTrackingService = new LinkTrackingService();
+
+export default linkTrackingService;


### PR DESCRIPTION
# ✨ Feat: 외부 유입 링크 추적 라우트 추가

> 브랜치: `feature/link-tracking` → `develop`

## 작업 내용 및 테스트 방법

### 배경

인스타그램 바이오 등 외부 채널 링크의 유입 추적을 위해 `/link/[channel]` 라우트를 추가했습니다. 사용자가 외부에서 이 링크로 접속하면 백엔드가 방문을 기록한 뒤 실제 목적지로 302 리다이렉트됩니다.

### 동작 흐름

```
[인스타 바이오] https://bbangle.com/link/instagram
   ↓
src/app/link/[channel]/route.ts (Route Handler)
   1) isLinkChannel('instagram') 검증
   2) LinkTrackingService.recordVisit({ channel, userAgent, referer, forwardedFor })
      ↓
      fetch ${API_URL}/link/INSTAGRAM (toUpperCase)
        - User-Agent, Referer, X-Forwarded-For 헤더 그대로 전달
        - redirect: 'manual' (302를 fetch가 따라가지 않도록)
        - cache: 'no-store'
      ↓
      백엔드: 방문 기록 후 302 + Location: <destination_url>
      ↓
      res.headers.get('location') 반환
   3) NextResponse.redirect(destinationUrl, 302)
   ↓
브라우저 → destination_url
```

### 주요 변경 사항

| 파일 | 역할 |
|------|------|
| `src/app/link/[channel]/route.ts` | Route Handler. 채널 검증 → 백엔드 호출 → 302 redirect |
| `src/domains/linktracking/queries/service.ts` | `LinkTrackingService extends Service`. `fetchExtend.get`으로 백엔드 호출 |
| `src/domains/linktracking/constants/linkChannel.ts` | `LINK_CHANNEL` (instagram, naver_blog) + `LinkChannel` 타입 + `isLinkChannel` 타입 가드 |

### 컨벤션 준수

- **Service 패턴**: 다른 도메인(`product`, `store`)과 동일하게 `Service` 베이스 클래스 상속, `fetchExtend` 사용
- **도메인 분리**: `domains/linktracking/` 폴더로 도메인 단위 모듈화
- **상수 위치**: 도메인 전용 상수는 `domains/{도메인}/constants/`에 배치

### 핵심 포인트

- **헤더 명시 전달**: Next.js의 server-side `fetch`는 기본적으로 클라이언트의 User-Agent / Referer를 자동으로 붙이지 않음. 백엔드가 정확한 fingerprint를 만들 수 있도록 원본 요청의 헤더를 명시적으로 forward.
- **`X-Forwarded-For`**: TCP 단에서는 Next.js 서버 IP가 보이므로 `X-Forwarded-For`에 원본 클라이언트 IP를 실어 백엔드가 정확한 IP로 fingerprint 생성하도록 함.
- **대소문자 처리**: 사용자 URL은 소문자(`/link/instagram` — 인스타 바이오에 자연스러움), 백엔드 enum과 매칭하기 위해 service 단에서 `toUpperCase()` 변환.
- **`redirect: 'manual'`**: fetch가 302를 자동 추적하면 destination 페이지를 가져오게 됨. Location 헤더만 추출해야 하므로 manual 모드 사용.
- **`dynamic = 'force-dynamic'`**: 정적 캐싱 방지. 방문마다 백엔드 호출 필수.

### 테스트

#### 사전 조건
- 백엔드 `feature/link-tracking` 브랜치 동작 중
- DB에 추적 링크 row 존재
  ```sql
  INSERT INTO tracking_link (channel, destination_url, created_at, modified_at, is_deleted)
  VALUES ('INSTAGRAM', 'https://bbangle.com/products/123', NOW(6), NOW(6), 0);
  ```

#### 케이스

| URL | 기대 동작 |
|-----|----------|
| `/link/instagram` | 302 → `https://bbangle.com/products/123` |
| `/link/INSTAGRAM` | 400 Invalid channel (소문자만 허용) |
| `/link/unknown` | 400 Invalid channel |
| `/link/instagram` (DB row 없을 때) | 404 Tracking link not found |

#### 중복 카운트 검증
- 동일 브라우저로 `/link/instagram` 두 번 접속 → 백엔드 `link_visit` 테이블에 두 번째 row의 `is_duplicate = 1` 확인

## To reviewers

- `LinkTrackingService`가 `Service` 베이스의 baseUrl(`/api/v1`)이 아닌 백엔드의 `/link/{channel}` 엔드포인트(api 경로 밖)를 호출하므로, 전체 URL을 직접 넘기는 escape hatch를 사용했습니다. 다른 서비스와 다른 부분이라 의도된 변경입니다.
- 백엔드 PR(`feature/link-tracking`)이 먼저 머지되어야 정상 동작합니다.
- 신규 채널 추가 시 백엔드 `LinkChannel` enum과 프론트 `LINK_CHANNEL` 상수를 함께 동기화해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 링크 추적 기능 추가: 사용자의 방문 기록을 자동으로 수집하고 추적합니다.
  * 채널별 링크 리다이렉트 지원: 유효한 채널을 통한 동적 링크 리다이렉트 기능을 구현했습니다.
  * 요청 정보 기록: 사용자 에이전트, 참조처, IP 주소 등의 요청 정보를 추적합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->